### PR TITLE
Update: Show ruleId in tips

### DIFF
--- a/eslint-server/src/server.ts
+++ b/eslint-server/src/server.ts
@@ -47,7 +47,7 @@ interface ESLintReport {
 
 function makeDiagnostic(problem: ESLintProblem): Diagnostic {
 	return {
-		message: problem.message,
+		message: `${problem.message} (${problem.ruleId})`,
 		severity: convertSeverity(problem.severity),
 		range: {
 			start: { line: problem.line - 1, character: problem.column - 1 },


### PR DESCRIPTION
Thank you for the excellent extension!

To show ruleId is helpful to developers.

- If people want to know the rule's details, they can search with the
ruleId.
- If people want to disable the warning, they can write a
disable-comment with the ruleId.

So I'd like to show ruleId in tips.