### PR TITLE
Add autofix supports.

### DIFF
--- a/eslint-server/src/lib/eslint.ts
+++ b/eslint-server/src/lib/eslint.ts
@@ -1,0 +1,33 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+export interface ESLintAutofixEdit {
+	range: [number, number];
+	text: string;
+}
+
+export interface ESLintProblem {
+	line: number;
+	column: number;
+	severity: number;
+	ruleId: string;
+	message: string;
+	fix?: ESLintAutofixEdit;
+}
+
+export interface ESLintDocumentReport {
+	filePath: string;
+	errorCount: number;
+	warningCount: number;
+	messages: ESLintProblem[];
+	output?: string;
+}
+
+export interface ESLintReport {
+	errorCount: number;
+	warningCount: number;
+	results: ESLintDocumentReport[];
+}

--- a/eslint-server/src/lib/protocol.ts
+++ b/eslint-server/src/lib/protocol.ts
@@ -25,12 +25,6 @@ export interface ESLintAutofixParams {
 	uri: string;
 
 	/**
-	 * The flag to indicate that this request target is being hidden.
-	 * If this is `true`, the server would rewrite the target file directly.
-	 */
-	hidden: boolean;
-
-	/**
 	 * The flag to indicate this request was triggered by saved.
 	 * If this is `true` and the `eslint.enableAutofixOnSave` configure is `false`, the request would be ignored.
 	 */

--- a/eslint-server/src/lib/protocol.ts
+++ b/eslint-server/src/lib/protocol.ts
@@ -1,0 +1,49 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import {RequestType} from 'vscode-languageserver';
+
+/**
+ * The autofix method is sent from the client to the server.
+ */
+export namespace ESLintAutofixRequest {
+	export const type: RequestType<ESLintAutofixParams, ESLintAutofixResult, void> = {
+		get method() { return 'eslint/executeAutofix'; }
+	};
+}
+
+/**
+ * The parameters of ESLint autofix request.
+ */
+export interface ESLintAutofixParams {
+	/**
+	 * The Uri of the target document.
+	 */
+	uri: string;
+
+	/**
+	 * The flag to indicate that this request target is being hidden.
+	 * If this is `true`, the server would rewrite the target file directly.
+	 */
+	hidden: boolean;
+
+	/**
+	 * The flag to indicate this request was triggered by saved.
+	 * If this is `true` and the `eslint.enableAutofixOnSave` configure is `false`, the request would be ignored.
+	 */
+	onSaved: boolean;
+}
+
+/**
+ * The result of ESLint autofix request.
+ */
+export interface ESLintAutofixResult {
+	/**
+	 * The fixed content.
+	 * This is `undefined` if no change.
+	 */
+	fixedContent: string;
+}

--- a/eslint-server/src/lib/protocol.ts
+++ b/eslint-server/src/lib/protocol.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import {RequestType} from 'vscode-languageserver';
+import {ESLintAutofixEdit} from "./eslint";
 
 /**
  * The autofix method is sent from the client to the server.
@@ -37,7 +38,8 @@ export interface ESLintAutofixParams {
 export interface ESLintAutofixResult {
 	/**
 	 * The fixed content.
-	 * This is `undefined` if no change.
+	 * This is an empty array if no change.
+	 * This is sorted by their position.
 	 */
-	fixedContent: string;
+	edits: ESLintAutofixEdit[];
 }

--- a/eslint-server/src/server.ts
+++ b/eslint-server/src/server.ts
@@ -210,12 +210,6 @@ connection.onRequest(ESLintAutofixRequest.type, (params) => {
 		Files.uriToFilePath(params.uri)
 	);
 
-	// Rewrite the file directly if the target document is being hidden.
-	if (params.hidden) {
-		lib.CLIEngine.outputFixes(report);
-		return {fixedContent: null};
-	}
-
 	return {fixedContent: report.results[0].output || null};
 });
 

--- a/eslint/extension.ts
+++ b/eslint/extension.ts
@@ -7,9 +7,9 @@
 import * as path from 'path';
 import { workspace, Disposable, ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, SettingMonitor, RequestType, TransportKind } from 'vscode-languageclient';
+import ESLintAutofixController from "./lib/eslint-autofix-controller";
 
 export function activate(context: ExtensionContext) {
-
 	// We need to go one level up since an extension compile the js code into
 	// the output folder.
 	let serverModule = path.join(__dirname, '..', 'server', 'server.js');
@@ -28,5 +28,8 @@ export function activate(context: ExtensionContext) {
 	}
 
 	let client = new LanguageClient('ESLint', serverOptions, clientOptions);
-	context.subscriptions.push(new SettingMonitor(client, 'eslint.enable').start());
+	context.subscriptions.push(
+		new SettingMonitor(client, 'eslint.enable').start(),
+		new ESLintAutofixController(client).start()
+	);
 }

--- a/eslint/lib/eslint-autofix-controller.ts
+++ b/eslint/lib/eslint-autofix-controller.ts
@@ -96,6 +96,7 @@ export default class ESLintAutofixController {
 		}
 
 		const uri = String(document.uri);
+		const version = document.version;
 		const filePath = document.uri.fsPath;
 
 		// Skip if it's recursively.
@@ -115,7 +116,7 @@ export default class ESLintAutofixController {
 			if (result.edits.length === 0) {
 				return true;
 			}
-			if (String(editor.document.uri) !== uri) {
+			if (String(editor.document.uri) !== uri || editor.document.version !== version) {
 				return false;
 			}
 

--- a/eslint/lib/eslint-autofix-controller.ts
+++ b/eslint/lib/eslint-autofix-controller.ts
@@ -1,0 +1,158 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import { commands, window, workspace, Disposable, Position, Range, TextDocument, TextEditor, Uri } from 'vscode';
+import { LanguageClient } from 'vscode-languageclient';
+import { ESLintAutofixRequest, ESLintAutofixParams, ESLintAutofixResult } from './protocol';
+
+/**
+ * The controller of ESLint Autofix.
+ *
+ * This monitors actions saving documents then executes Autofix.
+ * And this monitors "eslint.executeAutofix" commands then executes Autofix.
+ *
+ * This sends "ESLintAutofixRequest" request to the server to execute Autofix.
+ * Then applies the result to documents.
+ */
+export default class ESLintAutofixController {
+	private disposable: Disposable;
+	private executingFlags: Map<string, boolean>;
+
+	/**
+	 * @param client - An interface which is used to send "ESLintAutofixRequest" request to the server.
+	 */
+	constructor(private client: LanguageClient) {
+		this.executingFlags = new Map<string, boolean>();
+	}
+
+	/**
+	 * Start listening events.
+	 */
+	start(): Disposable {
+		this.disposable = Disposable.from(
+			workspace.onDidSaveTextDocument(this.onSaved, this),
+			commands.registerTextEditorCommand("eslint.executeAutofix", this.onExecute, this)
+		);
+		return this;
+	}
+
+	/**
+	 * Stop listening events.
+	 */
+	dispose(): void {
+		if (this.disposable != null) {
+			this.disposable.dispose();
+			this.disposable = null;
+		}
+	}
+
+	/**
+	 * This would be called by DidSaveTextDocument event.
+	 * Then if the document is "javascript" or "javascriptreact", this executes Autofix.
+	 *
+	 * - If "eslint.enable" or "eslint.enableAutofixOnSave" is "false", the server does nothing.
+	 * - If the document is hidden, the server does write the result of Autofix to the file directly.
+	 */
+	private onSaved(document: TextDocument): void {
+		if (document.languageId.startsWith("javascript")) {
+			const editor = window.visibleTextEditors.find(e => e.document === document);
+			this.executeAutofix(document, editor, true);
+		}
+	}
+
+	/**
+	 * This would be called by "eslint.executeAutofix" command.
+	 * Then if the document is "javascript" or "javascriptreact", this executes Autofix.
+	 *
+	 * - If "eslint.enable" is "false", the server does nothing.
+	 */
+	private onExecute(editor: TextEditor): void {
+		const document = editor.document;
+
+		if (document.languageId.startsWith("javascript")) {
+			this.executeAutofix(document, editor, false);
+		}
+	}
+
+	/**
+	 * Execute Autofix on a given document.
+	 *
+	 * @param document - A document to execute Autofix.
+	 * @param editor - An editor that the document is staying.
+	 * @param onSaved - A flag to indicate that this was called by a save action.
+	 */
+	private executeAutofix(document: TextDocument, editor: TextEditor, onSaved: boolean): void {
+		if (this.client.needsStart()) {
+			console.log("executeAutofix: skipped because the client hasn't started yet.");
+			return;
+		}
+
+		const uri = String(document.uri);
+		const hidden = editor == null;
+
+		// Skip if it's recursively.
+		if (this.executingFlags.get(uri)) {
+			console.log("executeAutofix: skipped because recursively.");
+			return;
+		}
+		this.executingFlags.set(uri, true);
+
+		console.log("executeAutofix: started " + document.uri.fsPath);
+
+		// Send an autofix request to the server.
+		this.client.sendRequest(ESLintAutofixRequest.type, {
+			uri: uri,
+			hidden: hidden,
+			onSaved: onSaved
+		}).then(result => {
+			// If "hidden" is "true", the server wrote the result to the file directly.
+			// Or if there are no change of Autofix then "result.fixedContent" is null.
+			// In those case, do nothing here.
+			if (hidden || result.fixedContent == null) {
+				return true;
+			}
+			if (String(editor.document.uri) !== uri) {
+				return false;
+			}
+
+			// Replace whole document with the autofix result.
+			return editor.edit(mutator => {
+				const wholeRange = editor.document.validateRange(new Range(
+					new Position(0, 0),
+					new Position(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY)
+				));
+				mutator.replace(wholeRange, result.fixedContent);
+			});
+		}).then(result => {
+			// If the trigger is "didSaveTextDocument", the document got dirty as a result of this edit.
+			// So it need to save the document again.
+			// Though the save action triggers Autofix recursively, it would be skipped.
+			if (result && onSaved && document.isDirty) {
+				return document.save();
+			}
+			return result;
+		}).then(
+			(result) => {
+				this.executingFlags.set(uri, false);
+				if (!result) {
+					window.showErrorMessage(
+						"Failed to apply the result of Autofix: " +
+						document.uri.fsPath
+					);
+				}
+				console.log("executeAutofix: done " + document.uri.fsPath);
+			},
+			(err) => {
+				this.executingFlags.set(uri, false);
+				window.showErrorMessage(
+					err && err.message ||
+					"Failed to execute Autofix: " + document.uri.fsPath
+				);
+				console.log("executeAutofix: done " + document.uri.fsPath);
+			}
+		);
+	}
+}

--- a/eslint/lib/eslint-autofix-controller.ts
+++ b/eslint/lib/eslint-autofix-controller.ts
@@ -122,7 +122,7 @@ export default class ESLintAutofixController {
 
 			// Replace whole document with the autofix result.
 			return editor.edit(mutator => {
-				this._applyEdit(mutator, document, result.edits);
+				this.applyEdit(mutator, document, result.edits);
 			});
 		}).then(result => {
 			// If the trigger is "didSaveTextDocument", the document got dirty as a result of this edit.
@@ -156,7 +156,7 @@ export default class ESLintAutofixController {
 	 * @param edits - The edits to be applied. This is sorted by their position.
 	 * @see https://github.com/eslint/eslint/blob/e5146e1dd546235b612c880498e89e0dbba7c4f8/lib/util/source-code-fixer.js#L57
 	 */
-	_applyEdit(mutator: TextEditorEdit, document: TextDocument, edits: ESLintAutofixEdit[]) {
+	private applyEdit(mutator: TextEditorEdit, document: TextDocument, edits: ESLintAutofixEdit[]) {
 		let lastFixPos = Number.POSITIVE_INFINITY;
 
 		for (let i = edits.length - 1; i >= 0; --i) {

--- a/eslint/lib/eslint.ts
+++ b/eslint/lib/eslint.ts
@@ -1,0 +1,10 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+export interface ESLintAutofixEdit {
+	range: [number, number];
+	text: string;
+}

--- a/eslint/lib/protocol.ts
+++ b/eslint/lib/protocol.ts
@@ -1,0 +1,50 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import {Uri} from 'vscode';
+import {RequestType} from 'vscode-languageclient';
+
+/**
+ * The autofix method is sent from the client to the server.
+ */
+export namespace ESLintAutofixRequest {
+	export const type: RequestType<ESLintAutofixParams, ESLintAutofixResult, void> = {
+		get method() { return 'eslint/executeAutofix'; }
+	};
+}
+
+/**
+ * The parameters of ESLint autofix request.
+ */
+export interface ESLintAutofixParams {
+	/**
+	 * The Uri of the target document.
+	 */
+	uri: string;
+
+	/**
+	 * The flag to indicate that this request target is being hidden.
+	 * If this is `true`, the server would rewrite the target file directly.
+	 */
+	hidden: boolean;
+
+	/**
+	 * The flag to indicate this request was triggered by saved.
+	 * If this is `true` and the `eslint.enableAutofixOnSave` configure is `false`, the request would be ignored.
+	 */
+	onSaved: boolean;
+}
+
+/**
+ * The result of ESLint autofix request.
+ */
+export interface ESLintAutofixResult {
+	/**
+	 * The fixed content.
+	 * This is `undefined` if no change.
+	 */
+	fixedContent?: string;
+}

--- a/eslint/lib/protocol.ts
+++ b/eslint/lib/protocol.ts
@@ -26,12 +26,6 @@ export interface ESLintAutofixParams {
 	uri: string;
 
 	/**
-	 * The flag to indicate that this request target is being hidden.
-	 * If this is `true`, the server would rewrite the target file directly.
-	 */
-	hidden: boolean;
-
-	/**
 	 * The flag to indicate this request was triggered by saved.
 	 * If this is `true` and the `eslint.enableAutofixOnSave` configure is `false`, the request would be ignored.
 	 */

--- a/eslint/lib/protocol.ts
+++ b/eslint/lib/protocol.ts
@@ -4,8 +4,8 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import {Uri} from 'vscode';
 import {RequestType} from 'vscode-languageclient';
+import {ESLintAutofixEdit} from "./eslint";
 
 /**
  * The autofix method is sent from the client to the server.
@@ -38,7 +38,8 @@ export interface ESLintAutofixParams {
 export interface ESLintAutofixResult {
 	/**
 	 * The fixed content.
-	 * This is `undefined` if no change.
+	 * This is an empty array if no change.
+	 * This is sorted by their position.
 	 */
-	fixedContent?: string;
+	edits: ESLintAutofixEdit[];
 }

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -21,7 +21,9 @@
 		"vscode": "^0.10.8"
 	},
 	"activationEvents": [
-		"onLanguage:javascript", "onLanguage:javascriptreact"
+		"onLanguage:javascript",
+		"onLanguage:javascriptreact",
+		"onCommand:eslint.executeAutofix"
 	],
 	"main": "./out/extension",
 	"contributes": {
@@ -33,6 +35,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Control whether eslint is enabled for JavaScript files or not."
+				},
+				"eslint.enableAutofixOnSave": {
+					"type": "boolean",
+					"default": false,
+					"description": "Control the flag to enable executing Autofix when you save a file."
 				},
 				"eslint.options": {
 					"type": "object",
@@ -49,6 +56,13 @@
 			{
 				"fileMatch": ".eslintrc.json",
 				"url": "http://json.schemastore.org/eslintrc"
+			}
+		],
+		"commands": [
+			{
+				"command": "eslint.executeAutofix",
+				"title": "Execute Autofix",
+				"category": "ESLint"
 			}
 		]
 	},

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -39,7 +39,7 @@
 				"eslint.enableAutofixOnSave": {
 					"type": "boolean",
 					"default": false,
-					"description": "Control the flag to enable executing Autofix when you save a file."
+					"description": "Control whether eslint errors are auto-fixed when a file is saved."
 				},
 				"eslint.options": {
 					"type": "object",


### PR DESCRIPTION
Refs #10 and #18.

Hello, thank you for the great extension!

The purpose of this PR is that adding the feature of ESLint's Autofix.
This PR is adding one command and one option.

- `eslint.executeAutofix` command executes Autofix on the current document.
  ![autofix-command](https://cloud.githubusercontent.com/assets/1937871/12384839/a4c77174-bdf9-11e5-8862-8025b2df7c71.gif)
- If `eslint.enableAutofixOnSave` option was enabled then it executes Autofix when you saved a document.
  ![autofix-on-save](https://cloud.githubusercontent.com/assets/1937871/12384873/0fd3c35a-bdfa-11e5-8be0-e6de8b7b2d9e.gif)

I'm happy if this PR is accepted.
And I'm happy to follow reviews and directions.

(I'm a beginner on TypeScript and VSCode extensions.)

Regards.