### PR TITLE
Chrisdias/license

### DIFF
--- a/eslint/package.json
+++ b/eslint/package.json
@@ -4,7 +4,7 @@
 	"description": "Integrates ESLint into VS Code.",
 	"version": "0.10.12",
 	"author": "Microsoft Corporation",
-	"license": "MIT",
+	"license": "SEE LICENSE in License.txt",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Microsoft/vscode-eslint.git"

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -4,7 +4,7 @@
 	"description": "Integrates ESLint into VS Code.",
 	"version": "0.10.12",
 	"author": "Microsoft Corporation",
-	"license": "SEE LICENSE in License.txt",
+	"license": "SEE LICENSE IN License.txt",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Microsoft/vscode-eslint.git"


### PR DESCRIPTION
The new "LICENSE" button in the command palette will open the [license in the marketplace](https://marketplace.visualstudio.com/items/dbaeumer.vscode-eslint/license):

![image](https://cloud.githubusercontent.com/assets/1487073/13424935/f8fed932-dfa3-11e5-9133-c390755e13ef.png)

In order for the marketplace to scrape the license you need to set the license property of package.json to "SEE LICENSE IN <<< filename >>>". This PR does this.

