### PR TITLE
fix(errors): hide ruleId if no ruleId applies. Closes #52

### DIFF
--- a/eslint-server/src/server.ts
+++ b/eslint-server/src/server.ts
@@ -46,8 +46,12 @@ interface ESLintReport {
 }
 
 function makeDiagnostic(problem: ESLintProblem): Diagnostic {
+	let message = `${problem.message}`;
+	if (problem.ruleId != null) {
+		message += ` (${problem.ruleId})`;
+	}
 	return {
-		message: `${problem.message} (${problem.ruleId})`,
+		message: message,
 		severity: convertSeverity(problem.severity),
 		source: 'eslint',
 		range: {


### PR DESCRIPTION
Hides the `(ruleId)` part from the message if the ruleId is null.