### PR TITLE
Support for specifying eslint module path

### DIFF
--- a/eslint/extension.ts
+++ b/eslint/extension.ts
@@ -64,7 +64,8 @@ export function activate(context: ExtensionContext) {
 
 	let configuration = workspace.getConfiguration('eslint');
 	clientOptions.initializationOptions = {
-		legacyModuleResolve: configuration ? configuration.get('_legacyModuleResolve', false) : false
+		legacyModuleResolve: configuration ? configuration.get('_legacyModuleResolve', false) : false,
+		relativeModulePath: configuration ? configuration.get('relativeModulePath', '') : ''
 	}
 
 	let client = new LanguageClient('ESLint', serverOptions, clientOptions);

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -36,6 +36,11 @@
 					"default": true,
 					"description": "Controls whether eslint is enabled for JavaScript files or not."
 				},
+				"eslint.relativeModulePath": {
+					"type": "string",
+					"default": "",
+					"description": "Path to the eslint module relative to workspace root. Use this if eslint is not installed in the root folder."
+				},
 				"eslint._legacyModuleResolve" : {
 					"type": "boolean",
 					"default": false,


### PR DESCRIPTION
This change adds a setting called `eslint.relativeModulePath`
which is helpful in the cases when the node_modules folder
might not reside in the root of the workspace.

Fixes #87 