### PR TITLE
preserve focus when showing output channel

### DIFF
--- a/eslint/extension.ts
+++ b/eslint/extension.ts
@@ -185,7 +185,7 @@ export function activate(context: ExtensionContext) {
 						}
 						if (!state.workspaces[workspace.rootPath]) {
 							state.workspaces[workspace.rootPath] = true;
-							client.outputChannel.show();
+							client.outputChannel.show(true);
 							context.globalState.update(key, state);
 						}
 					} else {
@@ -196,17 +196,17 @@ export function activate(context: ExtensionContext) {
 						].join('\n'));
 						if (!state.global) {
 							state.global = true;
-							client.outputChannel.show();
+							client.outputChannel.show(true);
 							context.globalState.update(key, state);
 						}
 					}
 				} else {
 					client.error('Server initialization failed.', error);
-					client.outputChannel.show();
+					client.outputChannel.show(true);
 				}
 			} else {
 				client.error('Server initialization failed.', error);
-				client.outputChannel.show();
+				client.outputChannel.show(true);
 			}
 			return false;
 		},


### PR DESCRIPTION
I would like to propose that we do not pass focus to the output channel when we open it automatically.

@dbaeumer fyi