### PR TITLE
Update statusBarItem color

### DIFF
--- a/eslint/extension.ts
+++ b/eslint/extension.ts
@@ -214,7 +214,7 @@ export function realActivate(context: ExtensionContext) {
 				statusBarItem.color = 'yellow';
 				break;
 			case Status.error:
-				statusBarItem.color = 'darkred';
+				statusBarItem.color = '#aaa';
 				break;
 		}
 		eslintStatus = status;
@@ -365,6 +365,7 @@ export function realActivate(context: ExtensionContext) {
 					context.globalState.update(key, state);
 				}
 			}
+			updateStatus(3);
 			return {};
 		});
 	});


### PR DESCRIPTION
When ESLint is not available, we should update the statusBarItem color to inform user. I think it will also fix https://github.com/Microsoft/vscode-eslint/issues/183.

<img width="132" alt="screen shot 2017-02-16 at 9 48 56 am" src="https://cloud.githubusercontent.com/assets/1091472/23003643/32009614-f42d-11e6-90a0-0a8de5c347d8.png">
