### PR TITLE
Fix resolving eslint when NODE_PATH has multiple entries

### DIFF
--- a/eslint-server/src/server.ts
+++ b/eslint-server/src/server.ts
@@ -351,7 +351,7 @@ documents.onDidOpen((event) => {
 			let file = uri.fsPath;
 			let directory = path.dirname(file);
 			if (nodePath) {
-				 promise = Files.resolve('eslint', nodePath, nodePath, trace).then<string>(undefined, () => {
+				 promise = Files.resolve('eslint', nodePath, directory, trace).then<string>(undefined, () => {
 					 return Files.resolve('eslint', globalNodePath, directory, trace);
 				 });
 			} else {


### PR DESCRIPTION
For my workspace setup I need to specify two paths in `NODE_PATH`. This should work, except currently the call to `Files.resolve` also uses `NODE_PATH` for the resolution process's current working directory, and cd'ing to `/somewhere:/somewhere/else` fails.

It looks like both `directory` or `workspacePath` are reasonable cwd choices instead; I picked `directory` to match the Promise rejection case below.