### PR TITLE
Fix typo: 'Happend'

### DIFF
--- a/eslint-server/src/server.ts
+++ b/eslint-server/src/server.ts
@@ -981,7 +981,7 @@ function tryHandleMissingModule(error: any, document: TextDocument, library: ESL
 				connection.console.error([
 					'',
 					`${error.message.toString()}`,
-					`Happend while validating ${fsPath ? fsPath : document.uri}`,
+					`Happened while validating ${fsPath ? fsPath : document.uri}`,
 					`This can happen for a couple of reasons:`,
 					`1. The plugin name is spelled incorrectly in an ESLint configuration file (e.g. .eslintrc).`,
 					`2. If ESLint is installed globally, then make sure ${module} is installed globally as well.`,


### PR DESCRIPTION
Context
![capture](https://user-images.githubusercontent.com/7544450/27753891-737c6630-5d9c-11e7-97ed-f6de9d30a09e.PNG)

Fixes typo in eslint console output.