### PR TITLE
Fix compile errors

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -15,8 +15,8 @@ import {
 	TextDocumentIdentifier, NotificationType, ErrorHandler,
 	ErrorAction, CloseAction, State as ClientState,
 	RevealOutputChannelOn, VersionedTextDocumentIdentifier, ExecuteCommandRequest, ExecuteCommandParams,
-	ServerOptions, ProposedProtocol, DocumentFilter, DidCloseTextDocumentNotification, DidOpenTextDocumentNotification,
-	ConfigurationParams, CancellationToken, WorkspaceFolder, WorkspaceMiddleware
+	ServerOptions, DocumentFilter, DidCloseTextDocumentNotification, DidOpenTextDocumentNotification,
+	Proposed, CancellationToken, WorkspaceFolder, WorkspaceMiddleware
 } from 'vscode-languageclient';
 
 const eslintrc: string = [
@@ -475,7 +475,7 @@ export function realActivate(context: ExtensionContext) {
 				return next(document, range, newContext, token);
 			},
 			workspace: {
-				configuration: (params: ConfigurationParams, _token: CancellationToken, _next: Function): any[] => {
+				configuration: (params: Proposed.ConfigurationParams, _token: CancellationToken, _next: Function): any[] => {
 					if (!params.items) {
 						return null;
 					}
@@ -574,7 +574,7 @@ export function realActivate(context: ExtensionContext) {
 	};
 
 	let client = new LanguageClient('ESLint', serverOptions, clientOptions);
-	client.registerFeatures(ProposedProtocol(client));
+	client.registerProposedFeatures();
 	defaultErrorHandler = client.createDefaultErrorHandler();
 	const running = 'ESLint server is running.';
 	const stopped = 'ESLint server stopped.'

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,7 +13,7 @@ import {
 	Command, IPCMessageReader, IPCMessageWriter, WorkspaceChange,
 	CodeActionRequest, VersionedTextDocumentIdentifier,
 	ExecuteCommandRequest, DidChangeWatchedFilesNotification, DidChangeConfigurationNotification,
-	ProposedProtocol, WorkspaceFolder, DidChangeWorkspaceFoldersNotification
+	WorkspaceFolder, ProposedFeatures, Proposed
 } from 'vscode-languageserver';
 
 import Uri from 'vscode-uri';
@@ -286,7 +286,7 @@ process.exit = (code?: number) => {
 	}, 1000);
 }
 
-let connection = createConnection(ProposedProtocol, new IPCMessageReader(process), new IPCMessageWriter(process));
+let connection = createConnection(ProposedFeatures.all, new IPCMessageReader(process), new IPCMessageWriter(process));
 let documents: TextDocuments = new TextDocuments();
 
 let globalNodePath: string = undefined;
@@ -607,14 +607,14 @@ connection.onInitialize((_params) => {
 
 connection.onInitialized(() => {
 	connection.client.register(DidChangeConfigurationNotification.type, undefined);
-	connection.client.register(DidChangeWorkspaceFoldersNotification.type, undefined);
+	connection.client.register(Proposed.DidChangeWorkspaceFoldersNotification.type, undefined);
 })
 
 messageQueue.registerNotification(DidChangeConfigurationNotification.type, (_params) => {
 	environmentChanged();
 });
 
-messageQueue.registerNotification(DidChangeWorkspaceFoldersNotification.type, (_params) => {
+messageQueue.registerNotification(Proposed.DidChangeWorkspaceFoldersNotification.type, (_params) => {
 	environmentChanged();
 });
 


### PR DESCRIPTION
This pull request should fix https://github.com/Microsoft/vscode-eslint/issues/291, there's still one compile error:

<img width="807" alt="screen shot 2017-09-09 at 9 49 33 pm" src="https://user-images.githubusercontent.com/1091472/30240760-cd263fa0-95a8-11e7-98da-d89c19e92d83.png">

I could remove it from the `import` and define an interface to fix it:

```ts
interface WorkspaceFolder {
	name: string;
	uri: string;
}
```
But I'm not sure it's the right way, so I'll leave it.

All of the fixes are collected from https://github.com/Microsoft/vscode-extension-samples, hope it helps.