### PR TITLE
Remove unused import (TextEditor)

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -7,7 +7,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import {
-	workspace as Workspace, window as Window, commands as Commands, languages as Languages, Disposable, ExtensionContext, Uri, StatusBarAlignment, TextEditor, TextDocument,
+	workspace as Workspace, window as Window, commands as Commands, languages as Languages, Disposable, ExtensionContext, Uri, StatusBarAlignment, TextDocument,
 	CodeActionContext, Diagnostic, ProviderResult, Command, QuickPickItem, WorkspaceFolder as VWorkspaceFolder
 } from 'vscode';
 import {


### PR DESCRIPTION
The most recent commit breaks the build (via a linter rule) by introducing an unused import. This PR removes that import.