### PR TITLE
update error message and add a hint to update yarn setting if using yarn

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -672,7 +672,8 @@ export function realActivate(context: ExtensionContext) {
 					client.info([
 						`Failed to load the ESLint library for the document ${uri.fsPath}`,
 						'To use ESLint for single JavaScript file install eslint globally using \'npm install -g eslint\'.',
-						'You need to reopen VS Code after installing eslint.',
+						'If you are using yarn instead of npm set the setting `"eslint.packageManager": "yarn"`',
+                                                'You need to reopen VS Code after installing eslint.',
 					].join('\n'));
 				}
 				if (!state.global) {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -650,6 +650,8 @@ export function realActivate(context: ExtensionContext) {
 						`To use ESLint please install eslint by running \'npm install eslint\' in the workspace folder ${workspaceFolder.name}`,
 						'or globally using \'npm install -g eslint\'. You need to reopen the workspace after installing eslint.',
 						'',
+						'If you are using yarn instead of npm set the setting `"eslint.packageManager": "yarn"`',
+						'',
 						`Alternatively you can disable ESLint for the workspace folder ${workspaceFolder.name} by executing the 'Disable ESLint' command.`
 					].join('\n'));
 				}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -675,7 +675,7 @@ export function realActivate(context: ExtensionContext) {
 						`Failed to load the ESLint library for the document ${uri.fsPath}`,
 						'To use ESLint for single JavaScript file install eslint globally using \'npm install -g eslint\'.',
 						'If you are using yarn instead of npm set the setting `"eslint.packageManager": "yarn"`',
-                                                'You need to reopen VS Code after installing eslint.',
+                                      		'You need to reopen VS Code after installing eslint.',
 					].join('\n'));
 				}
 				if (!state.global) {


### PR DESCRIPTION
Modify error message when eslint can't be found to improve the user experience.  Since npm is the default setting but most people are using yarn (see state of js data) including the vs code examples, add "If you are using yarn instead of npm set the setting `"eslint.packageManager": "yarn"`".  An even more improved user experience would be to check both.  see #374 