### PR TITLE
Use eslint --init to generate configuration

### DIFF
--- a/client/src/command.ts
+++ b/client/src/command.ts
@@ -1,0 +1,21 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+function exists(file: string): Promise<boolean> {
+	return new Promise<boolean>((resolve, _reject) => {
+		fs.exists(file, (value) => {
+			resolve(value);
+		});
+	});
+}
+
+export async function findEslint(rootPath: string): Promise<string> {
+	const platform = process.platform;
+	if (platform === 'win32' && await exists(path.join(rootPath, 'node_modules', '.bin', 'eslint.cmd'))) {
+		return path.join('.', 'node_modules', '.bin', 'eslint.cmd');
+	} else if ((platform === 'linux' || platform === 'darwin') && await exists(path.join(rootPath, 'node_modules', '.bin', 'eslint'))) {
+		return path.join('.', 'node_modules', '.bin', 'eslint');
+	} else {
+		return 'eslint';
+	}
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -19,6 +19,7 @@ import {
 	WorkspaceFolder
 } from 'vscode-languageclient';
 
+import { findEslint } from './command';
 import { TaskProvider } from './tasks';
 
 namespace Is {
@@ -206,15 +207,17 @@ function createDefaultConfiguration(): void {
 		}
 		return;
 	}
-	pickFolder(noConfigFolders, 'Select a workspace folder to generate a ESLint configuration for').then(folder => {
+	pickFolder(noConfigFolders, 'Select a workspace folder to generate a ESLint configuration for').then(async (folder) => {
 		if (!folder) {
 			return;
 		}
+		const folderRootPath = folder.uri.fsPath
 		const terminal = Window.createTerminal({
 			name: `ESLint init`,
-			cwd: folder.uri.fsPath
+			cwd: folderRootPath
 		});
-		terminal.sendText('eslint --init');
+		const eslintCommand = await findEslint(folderRootPath);
+		terminal.sendText(`${eslintCommand} --init`);
 		terminal.show();
 	});
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -21,52 +21,6 @@ import {
 
 import { TaskProvider } from './tasks';
 
-const eslintrcJson: string = [
-'{',
-'    "env": {',
-'        "browser": true,',
-'        "commonjs": true,',
-'        "es6": true,',
-'        "node": true',
-'    },',
-'    "parserOptions": {',
-'        "ecmaFeatures": {',
-'            "jsx": true',
-'        },',
-'        "sourceType": "module"',
-'    },',
-'    "rules": {',
-'        "no-const-assign": "warn",',
-'        "no-this-before-super": "warn",',
-'        "no-undef": "warn",',
-'        "no-unreachable": "warn",',
-'        "no-unused-vars": "warn",',
-'        "constructor-super": "warn",',
-'        "valid-typeof": "warn"',
-'    }',
-'}'
-].join(process.platform === 'win32' ? '\r\n' : '\n');
-
-const eslintrcYaml: string = [
-'env:',
-'    browser: true',
-'    commonjs: true',
-'    es6: true',
-'    node: true',
-'parserOptions:',
-'    ecmaFeatures:',
-'        jsx: true',
-'    sourceType: module',
-'rules:',
-'    no-const-assign: warn',
-'    no-this-before-super: warn',
-'    no-undef: warn',
-'    no-unreachable: warn',
-'    no-unused-vars: warn',
-'    constructor-super: warn',
-'    valid-typeof: warn'
-].join(process.platform === 'win32' ? '\r\n' : '\n');
-
 namespace Is {
 	const toString = Object.prototype.toString;
 
@@ -229,7 +183,7 @@ function disable() {
 	});
 }
 
-function createDefaultConfiguration(asJson: boolean): void {
+function createDefaultConfiguration(): void {
 	let folders = Workspace.workspaceFolders;
 	if (!folders) {
 		Window.showErrorMessage('An ESLint configuration can only be generated if VS Code is opened on a workspace folder.');
@@ -256,21 +210,10 @@ function createDefaultConfiguration(asJson: boolean): void {
 		if (!folder) {
 			return;
 		}
-		const eslintConfigFileExtension = asJson ? 'json' : 'yml';
-		let eslintConfigFile = path.join(folder.uri.fsPath, `.eslintrc.${eslintConfigFileExtension}`);
-		if (!fs.existsSync(eslintConfigFile)) {
-			const eslintrc = asJson ? eslintrcJson : eslintrcYaml;
-			fs.writeFileSync(eslintConfigFile, eslintrc, { encoding: 'utf8' });
-		}
+		const terminal = Window.createTerminal(`ESLint init`);
+		terminal.sendText('eslint --init');
+		terminal.show();
 	});
-}
-
-function createDefaultConfigurationJson(): void {
-	createDefaultConfiguration(true);
-}
-
-function createDefaultConfigurationYaml(): void {
-	createDefaultConfiguration(false);
 }
 
 let dummyCommands: Disposable[];
@@ -332,8 +275,7 @@ export function activate(context: ExtensionContext) {
 	];
 
 	context.subscriptions.push(
-		Commands.registerCommand('eslint.createConfig', createDefaultConfigurationJson),
-		Commands.registerCommand('eslint.createConfigYaml', createDefaultConfigurationYaml),
+		Commands.registerCommand('eslint.createConfig', createDefaultConfiguration),
 		Commands.registerCommand('eslint.enable', enable),
 		Commands.registerCommand('eslint.disable', disable)
 	);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -210,7 +210,10 @@ function createDefaultConfiguration(): void {
 		if (!folder) {
 			return;
 		}
-		const terminal = Window.createTerminal(`ESLint init`);
+		const terminal = Window.createTerminal({
+			name: `ESLint init`,
+			cwd: folder.uri.fsPath
+		});
 		terminal.sendText('eslint --init');
 		terminal.show();
 	});

--- a/client/src/tasks.ts
+++ b/client/src/tasks.ts
@@ -4,18 +4,9 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import * as fs from 'fs';
-import * as path from 'path';
-
 import * as vscode from 'vscode';
 
-function exists(file: string): Promise<boolean> {
-	return new Promise<boolean>((resolve, _reject) => {
-		fs.exists(file, (value) => {
-			resolve(value);
-		});
-	});
-}
+import { findEslint } from './command';
 
 interface EslintTaskDefinition extends vscode.TaskDefinition {
 }
@@ -44,15 +35,7 @@ class FolderTaskProvider {
 			return undefined;
 		}
 		try {
-			let platform = process.platform;
-			let command: string;
-			if (platform === 'win32' && await exists(path.join(rootPath, 'node_modules', '.bin', 'eslint.cmd'))) {
-				command = path.join('.', 'node_modules', '.bin', 'eslint.cmd');
-			} else if ((platform === 'linux' || platform === 'darwin') && await exists(path.join(rootPath!, 'node_modules', '.bin', 'eslint'))) {
-				command = path.join('.', 'node_modules', '.bin', 'eslint');
-			} else {
-				command = 'eslint';
-			}
+			let command = await findEslint(rootPath);
 
 			let kind: EslintTaskDefinition = {
 				type: "eslint"

--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
 				"command": "eslint.createConfig"
 			},
 			{
+				"title": "Create '.eslintrc.yml' File",
+				"category": "ESLint",
+				"command": "eslint.createConfigYaml"
+			},
+			{
 				"title": "Enable ESLint",
 				"category": "ESLint",
 				"command": "eslint.enable"

--- a/package.json
+++ b/package.json
@@ -171,14 +171,9 @@
 				"command": "eslint.executeAutofix"
 			},
 			{
-				"title": "Create '.eslintrc.json' File",
+				"title": "Create ESLint configuration",
 				"category": "ESLint",
 				"command": "eslint.createConfig"
-			},
-			{
-				"title": "Create '.eslintrc.yml' File",
-				"category": "ESLint",
-				"command": "eslint.createConfigYaml"
 			},
 			{
 				"title": "Enable ESLint",


### PR DESCRIPTION
The extension currently has a command to `Create '.eslintrc.json' file`, but I would prefer to use `.eslintrc.yml`.
This PR adds functionality to generate a Yaml file with the same settings as the JSON.

closes #409 
