### PR TITLE
Allow setting the node runtime to use for the language server. Fixes #345

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This extension contributes the following variables to the [settings](https://cod
 ```
 - `eslint.run` - run the linter `onSave` or `onType`, default is `onType`.
 - `eslint.autoFixOnSave` - enables auto fix on save. Please note auto fix on save is only available if VS Code's `files.autoSave` is either `off`, `onFocusChange` or `onWindowChange`. It will not work with `afterDelay`.
-- `eslint.server.runtime` - use this setting to set the path of the node runtime to run ESLint under.
+- `eslint.runtime` - use this setting to set the path of the node runtime to run ESLint under.
 - `eslint.nodePath` - use this setting if an installed ESLint package can't be detected, for example `/myGlobalNodePackages/node_modules`.
 - `eslint.validate` - an array of language identifiers specify the files to be validated. Something like `"eslint.validate": [ "javascript", "javascriptreact", "html" ]`. If the setting is missing, it defaults to `["javascript", "javascriptreact"]`. You can also control which plugins should provide autofix support. To do so simply provide an object literal in the validate setting with the properties `language` and `autoFix` instead of a simple `string`. An example is:
 ```json

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This extension contributes the following variables to the [settings](https://cod
 ```
 - `eslint.run` - run the linter `onSave` or `onType`, default is `onType`.
 - `eslint.autoFixOnSave` - enables auto fix on save. Please note auto fix on save is only available if VS Code's `files.autoSave` is either `off`, `onFocusChange` or `onWindowChange`. It will not work with `afterDelay`.
+- `eslint.server.runtime` - use this setting to set the path of the node runtime to run ESLint under.
 - `eslint.nodePath` - use this setting if an installed ESLint package can't be detected, for example `/myGlobalNodePackages/node_modules`.
 - `eslint.validate` - an array of language identifiers specify the files to be validated. Something like `"eslint.validate": [ "javascript", "javascriptreact", "html" ]`. If the setting is missing, it defaults to `["javascript", "javascriptreact"]`. You can also control which plugins should provide autofix support. To do so simply provide an object literal in the validate setting with the properties `language` and `autoFix` instead of a simple `string`. An example is:
 ```json

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -335,7 +335,7 @@ export function realActivate(context: ExtensionContext) {
 	// the output folder.
 	// serverModule
 	let serverModule = context.asAbsolutePath(path.join('server', 'out', 'eslintServer.js'));
-	let runtime = Workspace.getConfiguration('eslint').get('server.runtime', null);
+	let runtime = Workspace.getConfiguration('eslint').get('runtime', null);
 	let serverOptions: ServerOptions = {
 		run: { module: serverModule, transport: TransportKind.ipc, runtime, options: { cwd: process.cwd() } },
 		debug: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv: ["--nolazy", "--inspect=6010"], cwd: process.cwd() } }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -335,9 +335,10 @@ export function realActivate(context: ExtensionContext) {
 	// the output folder.
 	// serverModule
 	let serverModule = context.asAbsolutePath(path.join('server', 'out', 'eslintServer.js'));
+	let runtime = Workspace.getConfiguration('eslint').get('server.runtime', null);
 	let serverOptions: ServerOptions = {
-		run: { module: serverModule, transport: TransportKind.ipc, options: { cwd: process.cwd() } },
-		debug: { module: serverModule, transport: TransportKind.ipc, options: { execArgv: ["--nolazy", "--inspect=6010"], cwd: process.cwd() } }
+		run: { module: serverModule, transport: TransportKind.ipc, runtime, options: { cwd: process.cwd() } },
+		debug: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv: ["--nolazy", "--inspect=6010"], cwd: process.cwd() } }
 	};
 
 	let defaultErrorHandler: ErrorHandler;

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
 					"default": false,
 					"description": "Controls whether a task for linting the whole workspace will be available."
 				},
-				"eslint.server.runtime": {
+				"eslint.runtime": {
 					"scope": "window",
 					"type": [
 						"string",

--- a/package.json
+++ b/package.json
@@ -161,6 +161,15 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Controls whether a task for linting the whole workspace will be available."
+				},
+				"eslint.server.runtime": {
+					"scope": "window",
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "The location of the node binary to run ESLint under."
 				}
 			}
 		},

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -325,6 +325,7 @@ process.on('uncaughtException', (error: any) => {
 });
 
 let connection = createConnection();
+connection.console.info(`ESLint server running in node ${process.version}`);
 let documents: TextDocuments = new TextDocuments();
 
 let _globalNpmPath: string | null | undefined;


### PR DESCRIPTION
Per the discussion in #345 it is useful toi be able to select the node version to run ESLint as. This adds the eslint.server.runtime setting which can be set to the path of the node binary to use.