### PR TITLE
Added Suppress rule for this line / Suppress rule for file quick actions / Show documentation

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -116,6 +116,18 @@ namespace NoESLintLibraryRequest {
 	export const type = new RequestType<NoESLintLibraryParams, NoESLintLibraryResult, void, void>('eslint/noLibrary');
 }
 
+interface OpenESLintDocParams {
+	url: string;
+}
+
+interface OpenESLintDocResult {
+
+}
+
+namespace OpenESLintDocRequest {
+	export const type = new RequestType<OpenESLintDocParams, OpenESLintDocResult, void, void>('eslint/openDoc');
+}
+
 const exitCalled = new NotificationType<[number, string], void>('eslint/exitCalled');
 
 
@@ -659,6 +671,11 @@ export function realActivate(context: ExtensionContext) {
 					context.globalState.update(key, state);
 				}
 			}
+			return {};
+		});
+
+		client.onRequest(OpenESLintDocRequest.type, (params) => {
+			Commands.executeCommand('vscode.open', Uri.parse(params.url));
 			return {};
 		});
 	});

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1086,18 +1086,20 @@ messageQueue.registerRequest(CodeActionRequest.type, (params) => {
 		let indentationText = /^([ \t]*)/.exec(lineText)[1];
 		workspaceChange.getTextEditChange({uri, version: editInfo.documentVersion}).add(createDisableLineTextEdit(editInfo, indentationText));
 		commands.set(`${CommandIds.applyDisableLine}:${disableRuleId}`, workspaceChange);
+		let title = `Suppress ${disableRuleId} for this line`;
 		result.push(CodeAction.create(
-			`Suppress ${disableRuleId} for this line`,
-			Command.create(editInfo.label, CommandIds.applyDisableLine, disableRuleId),
+			title,
+			Command.create(title, CommandIds.applyDisableLine, disableRuleId),
 			CodeActionKind.QuickFix
 		));
 
 		workspaceChange = new WorkspaceChange();
 		workspaceChange.getTextEditChange({uri, version: editInfo.documentVersion}).add(createDisableFileTextEdit(editInfo));
 		commands.set(`${CommandIds.applyDisableFile}:${disableRuleId}`, workspaceChange);
+		title = `Suppress ${disableRuleId} for the entire file`;
 		result.push(CodeAction.create(
-			`Suppress ${disableRuleId} for the entire file`,
-			Command.create(editInfo.label, CommandIds.applyDisableFile, disableRuleId),
+			title,
+			Command.create(title, CommandIds.applyDisableFile, disableRuleId),
 			CodeActionKind.QuickFix
 		));
 	};


### PR DESCRIPTION
* Added Suppress rule for this line / Suppress rule for file quick actions (#245)

![eslint](https://user-images.githubusercontent.com/246062/44614917-5b387e80-a871-11e8-8118-4131fb16f889.gif)

* Added show documentation quick action

* Fix possible issue with incorrect command run when 2 rule single fixes are available. This is due to `CommandIds.applySingleFix` getting overriden inside `commands` by the last added single fix quick action. The fix is to include the `ruleId` in the key when adding to `commands`.