### PR TITLE
Add link to ESLint rules via url attribute of the Diagnostic API

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4,13 +4,18 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"eslint-rule-documentation": {
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.21.tgz",
+			"integrity": "sha512-XW/SKOQnvyg6SJQ7BcM4R5vJ6N5ivA6Jqbh4GPPjBwee4Jj1Bne9R1JM5duMObtNiYfeQt/yYIAsHCDttFbTsA=="
+		},
 		"vscode-languageserver": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.1.0.tgz",
 			"integrity": "sha512-CIsrgx2Y5VHS317g/HwkSTWYBIQmy0DwEyZPmB2pEpVOhYFwVsYpbiJwHIIyLQsQtmRaO4eA2xM8KPjNSdXpBw==",
 			"requires": {
 				"vscode-languageserver-protocol": "3.13.0",
-				"vscode-uri": "1.0.6"
+				"vscode-uri": "^1.0.6"
 			},
 			"dependencies": {
 				"vscode-jsonrpc": {
@@ -23,7 +28,7 @@
 					"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
 					"integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
 					"requires": {
-						"vscode-jsonrpc": "4.0.0",
+						"vscode-jsonrpc": "^4.0.0",
 						"vscode-languageserver-types": "3.13.0"
 					}
 				},

--- a/server/package.json
+++ b/server/package.json
@@ -14,8 +14,9 @@
 		"node": "*"
 	},
 	"dependencies": {
-		"vscode-uri": "^1.0.1",
-		"vscode-languageserver": "^5.1.0"
+		"eslint-rule-documentation": "^1.0.21",
+		"vscode-languageserver": "^5.1.0",
+		"vscode-uri": "^1.0.1"
 	},
 	"scripts": {}
 }

--- a/server/src/eslint-rule-documentation.d.ts
+++ b/server/src/eslint-rule-documentation.d.ts
@@ -1,0 +1,7 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+declare module "eslint-rule-documentation" {
+	export default function ruleURI(ruleId: string): { found: boolean, url: string };
+}

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -17,6 +17,7 @@ import {
 } from 'vscode-languageserver';
 
 import URI from 'vscode-uri';
+import * as ruleURI from 'eslint-rule-documentation';
 import * as path from 'path';
 import {EOL} from 'os';
 
@@ -851,10 +852,17 @@ function validate(document: TextDocument, settings: TextDocumentSettings, publis
 		// cache documentation urls for all rules
 		if (!ruleDocData.handled.has(uri)) {
 			ruleDocData.handled.add(uri);
-			cli.getRules().forEach((rule, key) => {
+			cli.getRules().forEach((rule, ruleId) => {
+				let url;
+
 				if (rule.meta && rule.meta.docs && Is.string(rule.meta.docs.url)) {
-					ruleDocData.urls.set(key, rule.meta.docs.url);
+					url = rule.meta.docs.url;
+				} else {
+					// @ts-ignore TODO: Should type-check the 3rd-party module.
+					url = ruleURI(ruleId).url;
 				}
+
+				ruleDocData.urls.set(ruleId, url);
 			});
 		}
 	} finally {


### PR DESCRIPTION
Fixes #151. Relies on https://github.com/Microsoft/vscode/pull/61436 to implement diagnostic URLs in VS Code (fixing https://github.com/Microsoft/vscode/issues/11847), as well as https://github.com/Microsoft/vscode-languageserver-node/pull/432.

This PR does three things:

1. Add `eslint-rule-documentation` to retrieve URLs as a fallback to the rules metadata, so older versions of ESLint / older versions of plugin rules can also benefit from URLs.
2. Make the URL retrieval work with versions of ESLint before v4.15.0 (2018-01-06), which introduced  `CLIEngine#getRules()`.
3. Use the (new) `url` attribute of diagnostics to forward the ESLint rule's URL to VS Code, for display wherever.

Changes 1. and 2. could be useful now without further changes in VS Code or anywhere else. I can make separate PRs for these if they seem desirable enough.

Here is what the end result looks like at the moment (WIP):
![wip-highlight-over-link](https://user-images.githubusercontent.com/877585/47265144-09883980-d52c-11e8-9522-4890544a6e03.png)

---

The instructions to try this out locally are at the end of https://github.com/Microsoft/vscode/pull/61436.