### PR TITLE
disable-eslint fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ This extension contributes the following variables to the [settings](https://cod
   will validate files inside the server directory with the server directory as the current working directory. Same for files in the client directory. If the setting is omitted the working directory is the workspace folder.
 
   The setting also supports literals of the form `{ "directory": string, "changeProcessCWD": boolean }` as elements. Use this form if you want to instruct ESLint to change the current working directory of the ESLint validation process to the value of `directory` as well. This is for example necessary if ESLint is used to validate relative import statements like `import A from 'components/A';` which would otherwise be resolved to the workspace folder root.
+- `eslint.suppressCodeActionComment` - choose to either add the `eslint-disable` comment on the `sameLine` or `newLine`.
+- `eslint.showSuppressCodeAction` - show suppress lint rule in the quick fix menu.
+- `eslint.showDocumentationCodeAction` - show documentation for lint rule in the quick fix menu.
 
 ## Commands:
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ This extension contributes the following variables to the [settings](https://cod
   will validate files inside the server directory with the server directory as the current working directory. Same for files in the client directory. If the setting is omitted the working directory is the workspace folder.
 
   The setting also supports literals of the form `{ "directory": string, "changeProcessCWD": boolean }` as elements. Use this form if you want to instruct ESLint to change the current working directory of the ESLint validation process to the value of `directory` as well. This is for example necessary if ESLint is used to validate relative import statements like `import A from 'components/A';` which would otherwise be resolved to the workspace folder root.
-- `eslint.suppressCodeActionComment` - choose to either add the `eslint-disable` comment on the `sameLine` or `newLine`.
-- `eslint.showSuppressCodeAction` - show suppress lint rule in the quick fix menu.
-- `eslint.showDocumentationCodeAction` - show documentation for lint rule in the quick fix menu.
+- `eslint.suppressCodeActionComment` - choose to either add the `eslint-disable` comment on the `newLine` or `sameLine`. `newLine` is the default.
+- `eslint.showSuppressCodeAction` - show suppress lint rule in the quick fix menu. `true` by default.
+- `eslint.showDocumentationCodeAction` - show documentation for lint rule in the quick fix menu. `true` by default.
 
 ## Commands:
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,15 @@ This extension contributes the following variables to the [settings](https://cod
   will validate files inside the server directory with the server directory as the current working directory. Same for files in the client directory. If the setting is omitted the working directory is the workspace folder.
 
   The setting also supports literals of the form `{ "directory": string, "changeProcessCWD": boolean }` as elements. Use this form if you want to instruct ESLint to change the current working directory of the ESLint validation process to the value of `directory` as well. This is for example necessary if ESLint is used to validate relative import statements like `import A from 'components/A';` which would otherwise be resolved to the workspace folder root.
-- `eslint.suppressCodeActionComment` - choose to either add the `eslint-disable` comment on the `newLine` or `sameLine`. `newLine` is the default.
-- `eslint.showSuppressCodeAction` - show suppress lint rule in the quick fix menu. `true` by default.
-- `eslint.showDocumentationCodeAction` - show documentation for lint rule in the quick fix menu. `true` by default.
+- `eslint.codeAction.suppressComment` - object with properties:
+  - `enable` - show suppress lint rule in the quick fix menu. `true` by default.
+  - `location` - choose to either add the `eslint-disable` comment on the `newLine` or `sameLine`. `newLine` is the default.
+  Example:
+  ```json
+  {"enable": true, "location": "sameLine"}
+  ```
+- `eslint.codeAction.showDocumentation` - object with properties:
+  - `enable` - show open lint rule documentation web page in the quick fix menu. `true` by default.
 
 ## Commands:
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -71,6 +71,9 @@ interface TextDocumentSettings {
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: DirectoryItem | undefined;
 	library: undefined;
+	suppressCodeActionComment: 'newLine' | 'sameLine';
+	showSuppressCodeAction: boolean;
+	showDocumentationCodeAction: boolean;
 }
 
 interface NoESLintState {
@@ -479,7 +482,10 @@ export function realActivate(context: ExtensionContext) {
 							nodePath: config.get('nodePath', undefined),
 							workingDirectory: undefined,
 							workspaceFolder: undefined,
-							library: undefined
+							library: undefined,
+							suppressCodeActionComment: config.get('suppressCodeActionComment', 'newLine'),
+							showSuppressCodeAction: config.get('showSuppressCodeAction', true),
+							showDocumentationCodeAction: config.get('showDocumentationCodeAction', true),
 						}
 						let document: TextDocument = syncedDocuments.get(item.scopeUri);
 						if (!document) {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -60,6 +60,11 @@ namespace DirectoryItem {
 
 type RunValues = 'onType' | 'onSave';
 
+interface SuppressCodeActionSettings {
+	enable: boolean;
+	location: 'newLine' | 'sameLine'
+}
+
 interface TextDocumentSettings {
 	validate: boolean;
 	packageManager: 'npm' | 'yarn';
@@ -71,9 +76,8 @@ interface TextDocumentSettings {
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: DirectoryItem | undefined;
 	library: undefined;
-	suppressCodeActionComment: 'newLine' | 'sameLine';
-	showSuppressCodeAction: boolean;
-	showDocumentationCodeAction: boolean;
+	suppressCodeAction: SuppressCodeActionSettings;
+	documentationCodeAction: { enable: boolean };
 }
 
 interface NoESLintState {
@@ -483,9 +487,8 @@ export function realActivate(context: ExtensionContext) {
 							workingDirectory: undefined,
 							workspaceFolder: undefined,
 							library: undefined,
-							suppressCodeActionComment: config.get('suppressCodeActionComment', 'newLine'),
-							showSuppressCodeAction: config.get('showSuppressCodeAction', true),
-							showDocumentationCodeAction: config.get('showDocumentationCodeAction', true),
+							suppressCodeAction: config.get('codeAction.suppressComment', {enable: true, location: 'newLine'} as SuppressCodeActionSettings),
+							documentationCodeAction: config.get('codeAction.showDocumentation', {enable: true}),
 						}
 						let document: TextDocument = syncedDocuments.get(item.scopeUri);
 						if (!document) {

--- a/package.json
+++ b/package.json
@@ -198,27 +198,43 @@
 					"default": null,
 					"description": "The location of the node binary to run ESLint under."
 				},
-				"eslint.suppressCodeActionComment": {
+				"eslint.codeAction.suppressComment": {
 					"scope": "resource",
-					"type": "string",
-					"enum": [
-						"newLine",
-						"sameLine"
-					],
-					"default": "newLine",
-					"description": "Configure the suppress rule code action to insert the disable comment on the same line or a new line."
+					"type": "object",
+					"default": {
+						"enable": true,
+						"location": "newLine"
+					},
+					"properties": {
+						"enable": {
+							"type": "boolean",
+							"default": true,
+							"description": "Show the suppress code actions."
+						},
+						"location": {
+							"type": "string",
+							"enum": [
+								"newLine",
+								"sameLine"
+							],
+							"default": "newLine",
+							"description": "Configure the suppress rule code action to insert the disable comment on the same line or a new line."
+						}
+					}
 				},
-				"eslint.showSuppressCodeAction": {
+				"eslint.codeAction.showDocumentation": {
 					"scope": "resource",
-					"type": "boolean",
-					"default": true,
-					"description": "Show the suppress code actions."
-				},
-				"eslint.showDocumentationCodeAction": {
-					"scope": "resource",
-					"type": "boolean",
-					"default": true,
-					"description": "Show the documentation code actions."
+					"type": "object",
+					"default": {
+						"enable": true
+					},
+					"properties": {
+						"enable": {
+							"type": "boolean",
+							"default": true,
+							"description": "Show the documentation code actions."
+						}
+					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -197,6 +197,28 @@
 					],
 					"default": null,
 					"description": "The location of the node binary to run ESLint under."
+				},
+				"eslint.suppressCodeActionComment": {
+					"scope": "resource",
+					"type": "string",
+					"enum": [
+						"newLine",
+						"sameLine"
+					],
+					"default": "newLine",
+					"description": "Configure the suppress rule code action to insert the disable comment on the same line or a new line."
+				},
+				"eslint.showSuppressCodeAction": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true,
+					"description": "Show the suppress code actions."
+				},
+				"eslint.showDocumentationCodeAction": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true,
+					"description": "Show the documentation code actions."
 				}
 			}
 		},

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -113,6 +113,11 @@ namespace DirectoryItem {
 	}
 }
 
+interface SuppressCodeActionSettings {
+	enable: boolean;
+	location: 'newLine' | 'sameLine'
+}
+
 interface TextDocumentSettings {
 	validate: boolean;
 	packageManager: 'npm' | 'yarn';
@@ -125,9 +130,8 @@ interface TextDocumentSettings {
 	workingDirectory: DirectoryItem | undefined;
 	library: ESLintModule | undefined;
 	resolvedGlobalPackageManagerPath: string | undefined;
-	suppressCodeActionComment: 'newLine' | 'sameLine';
-	showSuppressCodeAction: boolean;
-	showDocumentationCodeAction: boolean;
+	suppressCodeAction: SuppressCodeActionSettings;
+	documentationCodeAction: { enable: boolean };
 }
 
 interface ESLintAutoFixEdit {
@@ -1134,9 +1138,9 @@ messageQueue.registerRequest(CodeActionRequest.type, (params) => {
 				));
 			}
 
-			if (settings.showSuppressCodeAction) {
+			if (settings.suppressCodeAction.enable) {
 				let workspaceChange = new WorkspaceChange();
-				if (settings.suppressCodeActionComment === 'sameLine') {
+				if (settings.suppressCodeAction.location === 'sameLine') {
 					workspaceChange.getTextEditChange({uri, version: documentVersion}).add(createDisableSameLineTextEdit(editInfo));
 				} else {
 					let lineText = textDocument.getText(Range.create(Position.create(editInfo.line - 1, 0), Position.create(editInfo.line - 1, Number.MAX_VALUE)));
@@ -1162,7 +1166,7 @@ messageQueue.registerRequest(CodeActionRequest.type, (params) => {
 				));
 			}
 
-			if (settings.showDocumentationCodeAction) {
+			if (settings.documentationCodeAction.enable) {
 				if (ruleDocData.urls.has(ruleId)) {
 					let title = `Show documentation for ${ruleId}`;
 					result.push(CodeAction.create(


### PR DESCRIPTION
* Fix issue with 'Fix all rule' quick action not appearing (mentioned in [comment of #530](https://github.com/Microsoft/vscode-eslint/pull/530#issuecomment-439315219))
* Add setting eslint.suppressCodeActionComment with options `sameLine` or `newLine` (#573)
* Add setting eslint.showSuppressCodeAction [comment of #530](https://github.com/Microsoft/vscode-eslint/pull/530#issuecomment-436269570)
* Add setting eslint.showDocumentationCodeAction [comment of #530](https://github.com/Microsoft/vscode-eslint/pull/530#issuecomment-436269570)