### PR TITLE
Autocomplete for eslint.codeAction.disableRuleComment should insert separateLine instead of newLine

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
 					"type": "object",
 					"default": {
 						"enable": true,
-						"location": "newLine"
+						"location": "separateLine"
 					},
 					"properties": {
 						"enable": {
@@ -218,7 +218,7 @@
 								"separateLine",
 								"sameLine"
 							],
-							"default": "newLine",
+							"default": "separateLine",
 							"description": "Configure the disable rule code action to insert the comment on the same line or a new line."
 						}
 					}


### PR DESCRIPTION
resolves #673

### Previous Behavior
Creating a rule for `eslint.codeAction.disableRuleComment` will autocomplete with `location: 'newLine'` and a warning that `newLine` is not a valid location.

### New Behavior
It should autocomplete with `location: 'separateLine'`