### PR TITLE
Added hideAutoFixedIssues option #267

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
 	"typescript.tsc.autoDetect": "off",
 	"tslint.enable": true,
 	"eslint.enable": false,
+	"eslint.hideAutoFixedIssues": true,
 	"eslint.trace.server": "off",
 	"eslint.provideLintTask": false
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This extension contributes the following variables to the [settings](https://cod
   ```
 - `eslint.run` - run the linter `onSave` or `onType`, default is `onType`.
 - `eslint.autoFixOnSave` - enables auto fix on save. Please note auto fix on save is only available if VS Code's `files.autoSave` is either `off`, `onFocusChange` or `onWindowChange`. It will not work with `afterDelay`.
+- `eslint.hideAutoFixedIssues` - don't show issues that will be fixed by `eslint.autoFixOnSave` on the next save.
 - `eslint.quiet` - ignore warnings.
 - `eslint.runtime` - use this setting to set the path of the node runtime to run ESLint under.
 - `eslint.nodePath` - use this setting if an installed ESLint package can't be detected, for example `/myGlobalNodePackages/node_modules`.

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -75,6 +75,7 @@ interface TextDocumentSettings {
 	packageManager: 'npm' | 'yarn' | 'pnpm';
 	autoFix: boolean;
 	autoFixOnSave: boolean;
+	hideAutoFix: boolean;
 	quiet: boolean;
 	options: any | undefined;
 	run: RunValues;
@@ -485,6 +486,7 @@ export function realActivate(context: ExtensionContext): void {
 							packageManager: config.get('packageManager', 'npm'),
 							autoFix: false,
 							autoFixOnSave: false,
+							hideAutoFix: false,
 							quiet: config.get('quiet', false),
 							options: config.get('options', {}),
 							run: config.get('run', 'onType'),
@@ -521,6 +523,7 @@ export function realActivate(context: ExtensionContext): void {
 						}
 						if (settings.validate) {
 							settings.autoFixOnSave = settings.autoFix && config.get('autoFixOnSave', false);
+							settings.hideAutoFix = settings.autoFixOnSave && config.get('hideAutoFixedIssues', false);
 						}
 						let workspaceFolder = Workspace.getWorkspaceFolder(resource);
 						if (workspaceFolder) {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,12 @@
 					"default": false,
 					"description": "Turns auto fix on save on or off."
 				},
+				"eslint.hideAutoFixedIssues": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"description": "Don't show issues that will be autofixed on the next save."
+				},
 				"eslint.quiet": {
 					"scope": "resource",
 					"type": "boolean",


### PR DESCRIPTION
This implements #267, effectively allowing ESLint to be used as an unintrusive, silent, highly configurable, automatic formatter!

I took the liberty to slightly refactor the issue aggregation loop at [eslintServer.ts#L889](https://github.com/kasvtv/vscode-eslint/blob/b5bdd909697451ca81e0c5cd74d670b9cf7e2429/server/src/eslintServer.ts#L889) by extracting some self-containable logic (checking if issue needs autofixing) into a function [eslintServer.ts#L825](https://github.com/kasvtv/vscode-eslint/blob/b5bdd909697451ca81e0c5cd74d670b9cf7e2429/server/src/eslintServer.ts#L825), to make it clearer what's going on and more maintainable.

Remarks:
- This is my first PR to this repo, I couldn't find any tests anywhere, so I only tested manually, is this a mistake on my part?
- I came across a little confusing piece of logic. Fix actions were being recorded even when `problem.fix`, `problem.ruleId` or `cli.getRules` were unavailable. I might be mistaken, but that seems incorrect, isn't it? I changed it to not report on these conditions [eslintServer.ts#L826](https://github.com/kasvtv/vscode-eslint/blob/b5bdd909697451ca81e0c5cd74d670b9cf7e2429/server/src/eslintServer.ts#L826), otherwise it would've lead to very non-idiomatic code. Let me know if I have to revert this.

Thanks! Hope this makes it into a release. Would be great if I can reduce my tooling and unify all my style settings in one single .eslintrc!