### PR TITLE
Fix None position values in publishDiagnostics message

### DIFF
--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -29,6 +29,10 @@ namespace Is {
 		return value === true || value === false;
 	}
 
+	export function nullOrUndefined(value: any): value is boolean {
+		return value === null || value === undefined;
+	}
+
 	export function string(value: any): value is string {
 		return toString.call(value) === '[object String]';
 	}
@@ -218,8 +222,8 @@ function makeDiagnostic(problem: ESLintProblem): Diagnostic {
 	let message = problem.message;
 	let startLine = Math.max(0, problem.line - 1);
 	let startChar = Math.max(0, problem.column - 1);
-	let endLine = problem.endLine !== null ? Math.max(0, problem.endLine - 1) : startLine;
-	let endChar = problem.endColumn !== null ? Math.max(0, problem.endColumn - 1) : startChar;
+	let endLine = Is.nullOrUndefined(problem.endLine) ? startLine : Math.max(0, problem.endLine - 1);
+	let endChar = Is.nullOrUndefined(problem.endColumn) ? startChar : Math.max(0, problem.endColumn - 1);
 	return {
 		message: message,
 		severity: convertSeverity(problem.severity),


### PR DESCRIPTION
For some issues eslint triggers error with no `endLine` and/or
`endColumn` defined. In that case the code should use `line` and
`column` for the values, respectively. While the code has attempted to
do that, it only checked for `null` value for those while eslint
actually doesn't even have them set so they are undefined.

Fix by checking that value is either null or undefined.

This problem causes random exceptions on some LSP clients (for me it
triggered in Sublime LSP). Not sure if it affected Vetur.

Resolves #752