### PR TITLE
Add `typescriptreact` to the README's TypeScript section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ To enable TypeScript file validation in the ESLint extension please add the foll
 
 ```json
 	"eslint.validate": [
-		{ "language": "typescript", "autoFix": true }
+		{ "language": "typescript", "autoFix": true },
+		{ "language": "typescriptreact", "autoFix": true }
 	]
 ```
 


### PR DESCRIPTION
VS Code wasn't linting my `.tsx` files even though running the CLI `eslint` with the correct glob patterns did the job. It took me thirty minutes to realize that this is because `tsx` files fell under the purview of `typescriptreact`, and so that also needed to be in `eslint.validate` for things to work as expected.