### PR TITLE
Coffeescript-specific comment syntax for disabling comments

### DIFF
--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1539,16 +1539,19 @@ messageQueue.registerRequest(CodeActionRequest.type, (params) => {
 		return TextEdit.replace(Range.create(textDocument!.positionAt(editInfo.edit.range[0]), textDocument!.positionAt(editInfo.edit.range[1])), editInfo.edit.text || '');
 	}
 
+	const languageSpecificLineCommentOpener = textDocument.languageId === 'coffeescript' ? '#' : '//';
+	const languageSpecificBlockCommentOpener = textDocument.languageId === 'coffeescript' ? '###' : '/*';
+	const languageSpecificBlockCommentCloser = textDocument.languageId === 'coffeescript' ? '###' : '*/';
 	function createDisableLineTextEdit(editInfo: Problem, indentationText: string): TextEdit {
-		return TextEdit.insert(Position.create(editInfo.line - 1, 0), `${indentationText}// eslint-disable-next-line ${editInfo.ruleId}${EOL}`);
+		return TextEdit.insert(Position.create(editInfo.line - 1, 0), `${indentationText}${languageSpecificLineCommentOpener} eslint-disable-next-line ${editInfo.ruleId}${EOL}`);
 	}
 
 	function createDisableSameLineTextEdit(editInfo: Problem): TextEdit {
-		return TextEdit.insert(Position.create(editInfo.line - 1, Number.MAX_VALUE), ` // eslint-disable-line ${editInfo.ruleId}`);
+		return TextEdit.insert(Position.create(editInfo.line - 1, Number.MAX_VALUE), ` ${languageSpecificLineCommentOpener} eslint-disable-line ${editInfo.ruleId}`);
 	}
 
 	function createDisableFileTextEdit(editInfo: Problem): TextEdit {
-		return TextEdit.insert(Position.create(0, 0), `/* eslint-disable ${editInfo.ruleId} */${EOL}`);
+		return TextEdit.insert(Position.create(0, 0), `${languageSpecificBlockCommentOpener} eslint-disable ${editInfo.ruleId} ${languageSpecificBlockCommentCloser}${EOL}`);
 	}
 
 	function getLastEdit(array: FixableProblem[]): FixableProblem | undefined {


### PR DESCRIPTION
@dbaeumer per #825 this PR makes the syntax for disabling comments language-specific so that when using the extension with Coffeescript source files it can generate the correct Coffeescript syntax for `eslint-disable*` comments

Fixes #825

Let me know if there's somewhere appropriate to add tests, I tested manually and saw the expected behavior for both Coffeescript and Javascript source files