### PR TITLE
Don't register DidChangeWorkspaceFoldersNotification dynamically

### DIFF
--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1091,7 +1091,6 @@ connection.onInitialize((_params, _cancel, progress) => {
 
 connection.onInitialized(() => {
 	connection.client.register(DidChangeConfigurationNotification.type, undefined);
-	connection.client.register(DidChangeWorkspaceFoldersNotification.type, undefined);
 });
 
 messageQueue.registerNotification(DidChangeConfigurationNotification.type, (_params) => {


### PR DESCRIPTION
Per documentation [1], server announces support for `workspace/didChangeWorkspaceFolders`
either through `workspace.workspaceFolders.supported` capability OR through
dynamic registration. Eslint server does both which is wrong [2].
And since eslint server doesn't ever unregister dynamic capability, there is
no point in going that route. Announcing capability from `onInitialize` is enough.

[1] https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWorkspaceFolders
[2] https://microsoft.github.io/language-server-protocol/specification#client_registerCapability