### PR TITLE
Fixes #945: Handle null setting in isExplicitlyDisabled

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -464,7 +464,7 @@ type CodeActionsOnSave = CodeActionsOnSaveMap | string[];
 
 namespace CodeActionsOnSave {
 	export function isExplicitlyDisabled(setting: CodeActionsOnSave | undefined): boolean {
-		if (setting === undefined || Array.isArray(setting)) {
+		if (!setting || Array.isArray(setting)) {
 			return false;
 		}
 		return setting['source.fixAll.eslint'] === false;


### PR DESCRIPTION
## Proposed changes
- In `CodeActionsOnSave. isExplicitlyDisabled()`, immediately return `false` when `setting` is falsy, as opposed to when `setting` is explicitly `undefined`.