### PR TITLE
Add setting to show linting errors as warnings

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -181,6 +181,7 @@ interface ConfigurationSettings {
 	nodePath: string | null;
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: ModeItem | DirectoryItem | undefined;
+	treatErrorsAsWarnings: boolean | undefined;
 }
 
 interface NoESLintState {
@@ -1097,7 +1098,8 @@ function realActivate(context: ExtensionContext): void {
 							codeAction: {
 								disableRuleComment: config.get('codeAction.disableRuleComment', { enable: true, location: 'separateLine' as 'separateLine' }),
 								showDocumentation: config.get('codeAction.showDocumentation', { enable: true })
-							}
+							},
+							treatErrorsAsWarnings: config.get('treatErrorsAsWarnings', false),
 						};
 						const document: TextDocument | undefined = syncedDocuments.get(item.scopeUri);
 						if (document === undefined) {

--- a/package.json
+++ b/package.json
@@ -362,6 +362,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Enables ESLint as a formatter."
+				},
+				"eslint.treatErrorsAsWarnings": {
+					"type": "boolean",
+					"default": false,
+					"description": "Any linting error reported by ESLint will instead be seen as a warning within VS Code."
 				}
 			}
 		},


### PR DESCRIPTION
Potentially closes #468. This adds a user-facing setting to override the diagnostic severity of any linting issue to be a warning, regardless of how rule severity is defined within the `eslintrc` configuration (especially if that configuration isn't in your control!).

The TSLint extension used to have this option which I rather liked, and with the eventual deprecation and move to ESLint I feel this extension should have a similar option. It's purely aesthetic, allowing me to easily differentiate between an actual typing error and a minor code style snag.

![image](https://user-images.githubusercontent.com/7294642/82837827-28963c80-9ec2-11ea-8feb-6e457d682da9.png)
![image](https://user-images.githubusercontent.com/7294642/82837935-862a8900-9ec2-11ea-9417-ea151129944c.png)
![image](https://user-images.githubusercontent.com/7294642/82837805-174d3000-9ec2-11ea-8a6f-361596da272b.png)

All comments welcome. I've opened a similar PR on the StandardJS extension as well.