### PR TITLE
Implement "eslint.rules.customizations" - Allow users to override rule severity from VS Code settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,16 @@ This extension contributes the following variables to the [settings](https://cod
 - `eslint.codeAction.showDocumentation` - object with properties:
   - `enable` - show open lint rule documentation web page in the quick fix menu. `true` by default.
 
-- `eslint.codeActionsOnSave.mode` (@since 2.0.12): controls which problems are fix when running code actions on save
+- `eslint.codeActionsOnSave.mode` (@since 2.0.12): controls which problems are fixed when running code actions on save
   - `all`: fixes all possible problems by revalidating the file's content. This executes the same code path as running eslint with the `--fix` option in the terminal and therefore can take some time. This is the default value.
   - `problems`: fixes only the currently known fixable problems as long as their textual edits are non overlapping. This mode is a lot faster but very likely only fixes parts of the problems.
+- `eslint.rules.customizations`: force rules to report a different severity within VS Code compared to the project's true ESLint configuration. This allows both a per-rule override, or an asterisk to set a default severity for all rules. These can be combined, such that all rules are just warnings except `no-extra-semi` in this example:
+  ```json
+    "eslint.rules.customizations": {
+      "no-extra-semi": "info",
+      "*": "warn"
+    }
+  ```
 
 - `eslint.format.enable` (@since 2.0.0): uses ESlint as a formatter for files that are validated by ESLint. If enabled please ensure to disable other formatters if you want to make this the default. A good way to do so is to add the following setting `"[javascript]": { "editor.defaultFormatter": "dbaeumer.vscode-eslint" }` for JavaScript. For TypeScript you need to add `"[typescript]": { "editor.defaultFormatter": "dbaeumer.vscode-eslint" }`.
 - `eslint.onIgnoredFiles` (@since 2.0.10): used to control whether warings should be generated when trying to lint ignored files. Default is `off`. Can be set to `warn`.

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -168,6 +168,12 @@ namespace ESLintSeverity {
 	}
 }
 
+enum RuleSeverity {
+	info = 'info',
+	warn = 'warn',
+	error = 'error'
+}
+
 interface ConfigurationSettings {
 	validate: Validate;
 	packageManager: 'npm' | 'yarn' | 'pnpm';
@@ -181,6 +187,9 @@ interface ConfigurationSettings {
 	nodePath: string | null;
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: ModeItem | DirectoryItem | undefined;
+	rulesCustomizations: {
+		'!'?: RuleSeverity
+	};
 }
 
 interface NoESLintState {
@@ -1097,7 +1106,8 @@ function realActivate(context: ExtensionContext): void {
 							codeAction: {
 								disableRuleComment: config.get('codeAction.disableRuleComment', { enable: true, location: 'separateLine' as 'separateLine' }),
 								showDocumentation: config.get('codeAction.showDocumentation', { enable: true })
-							}
+							},
+							rulesCustomizations: config.get('rules.customizations', {})
 						};
 						const document: TextDocument | undefined = syncedDocuments.get(item.scopeUri);
 						if (document === undefined) {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -188,7 +188,7 @@ interface ConfigurationSettings {
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: ModeItem | DirectoryItem | undefined;
 	rulesCustomizations: {
-		'!'?: RuleSeverity
+		'*'?: RuleSeverity
 	};
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -188,7 +188,8 @@ interface ConfigurationSettings {
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: ModeItem | DirectoryItem | undefined;
 	rulesCustomizations: {
-		'*'?: RuleSeverity
+		// One of these may be an asterisk to represent all rules.
+		[ruleName: string]: RuleSeverity;
 	};
 }
 

--- a/package.json
+++ b/package.json
@@ -362,6 +362,24 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Enables ESLint as a formatter."
+				},
+				"eslint.rules.customizations": {
+					"scope": "resource",
+					"anyOf": [
+						{
+							"type": "object",
+							"properties": {
+								"!": {
+									"type": "string",
+									"enum": [
+										"info",
+										"warn",
+										"error"
+									]
+								}
+							}
+						}
+					]
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -365,21 +365,16 @@
 				},
 				"eslint.rules.customizations": {
 					"scope": "resource",
-					"anyOf": [
-						{
-							"type": "object",
-							"properties": {
-								"!": {
-									"type": "string",
-									"enum": [
-										"info",
-										"warn",
-										"error"
-									]
-								}
-							}
-						}
-					]
+					"type": "object",
+					"description": "Override the severity of one or more rules reported by this extension, regardless of the project's ESLint config. Use an asterisk to apply a default severity for all rules.",
+					"additionalProperties": {
+						"type": "string",
+						"enum": [
+							"info",
+							"warn",
+							"error"
+						]
+					}
 				}
 			}
 		},

--- a/playgrounds/ts/.vscode/settings.json
+++ b/playgrounds/ts/.vscode/settings.json
@@ -6,6 +6,7 @@
 	"eslint.format.enable": true,
 	"eslint.trace.server": "off",
 	"eslint.rules.customizations": {
-		"*": "info"
+		"no-extra-semi": "info",
+		"*": "warn"
 	}
 }

--- a/playgrounds/ts/.vscode/settings.json
+++ b/playgrounds/ts/.vscode/settings.json
@@ -4,5 +4,8 @@
 		"source.fixAll.eslint": true
 	},
 	"eslint.format.enable": true,
-	"eslint.trace.server": "off"
+	"eslint.trace.server": "off",
+	"eslint.rules.customizations": {
+		"!": "info"
+	}
 }

--- a/playgrounds/ts/.vscode/settings.json
+++ b/playgrounds/ts/.vscode/settings.json
@@ -6,6 +6,6 @@
 	"eslint.format.enable": true,
 	"eslint.trace.server": "off",
 	"eslint.rules.customizations": {
-		"!": "info"
+		"*": "info"
 	}
 }

--- a/playgrounds/ts/test.ts
+++ b/playgrounds/ts/test.ts
@@ -1,4 +1,5 @@
 export function main(): number {
 	let s = '';
+	if (s == 'y') console.log('n');
 	return -1;;
 }

--- a/playgrounds/ts/test.ts
+++ b/playgrounds/ts/test.ts
@@ -1,4 +1,4 @@
 export function main(): number {
 	let s = '';
-	return -1;
+	return -1;;
 }

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -343,8 +343,8 @@ function loadNodeModule<T>(moduleName: string): T | undefined {
 
 function makeDiagnostic(problem: ESLintProblem): Diagnostic {
 	const message = problem.message;
-	const startLine = Math.max(0, problem.line - 1);
-	const startChar = Math.max(0, problem.column - 1);
+	const startLine = Is.nullOrUndefined(problem.line) ? 0 : Math.max(0, problem.line - 1);
+	const startChar = Is.nullOrUndefined(problem.column) ? 0 : Math.max(0, problem.column - 1);
 	const endLine = Is.nullOrUndefined(problem.endLine) ? startLine : Math.max(0, problem.endLine - 1);
 	const endChar = Is.nullOrUndefined(problem.endColumn) ? startChar : Math.max(0, problem.endColumn - 1);
 	const result: Diagnostic = {

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -207,7 +207,7 @@ interface CommonSettings {
 	nodePath: string | null;
 	workspaceFolder: WorkspaceFolder | undefined;
 	rulesCustomizations: {
-		'!'?: RuleSeverity
+		'*'?: RuleSeverity
 	};
 }
 

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -188,6 +188,12 @@ interface CodeActionsOnSaveSettings {
 	mode: CodeActionsOnSaveMode
 }
 
+enum RuleSeverity {
+	info = 'info',
+	warn = 'warn',
+	error = 'error'
+}
+
 interface CommonSettings {
 	validate: Validate;
 	packageManager: 'npm' | 'yarn' | 'pnpm';
@@ -200,6 +206,9 @@ interface CommonSettings {
 	run: RunValues;
 	nodePath: string | null;
 	workspaceFolder: WorkspaceFolder | undefined;
+	rulesCustomizations: {
+		'!'?: RuleSeverity
+	};
 }
 
 interface ConfigurationSettings extends CommonSettings {


### PR DESCRIPTION
This hopefully closes #468 based on the discussions in #561.

This PR implements a new extension option, allowing diagnostics reported by the ESLint extension to be overridden by user settings within VS Code. The main usecase is to allow linting errors to be visually different to actual typing/compilation problems based on personal preference, especially if adjusting the ESLint configuration itself is difficult (e.g. it's prepackaged, StandardJS, etc) or there's a fear of committing these customizations accidentally.

For example, the playground environment in this PR:
![image](https://user-images.githubusercontent.com/7294642/84591240-c41d2c00-ae34-11ea-9cc1-576ba77501c5.png)
![image](https://user-images.githubusercontent.com/7294642/84591255-ea42cc00-ae34-11ea-9cf8-899b2c2bdc34.png)
![image](https://user-images.githubusercontent.com/7294642/84591272-fe86c900-ae34-11ea-9df5-d0e42358b962.png)

The `eqeqeq` rule is an error in ESLint parlance, but the `*` override forces it to be a nicer yellow warning. I personally prefer this representation of all linting warnings.

---

All comments are welcome.