### PR TITLE
Add `additionalProperties: false` to some settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,8 @@
 							"default": "separateLine",
 							"description": "Configure the disable rule code action to insert the comment on the same line or a new line."
 						}
-					}
+					},
+					"additionalProperties": false
 				},
 				"eslint.codeAction.showDocumentation": {
 					"scope": "resource",
@@ -341,7 +342,8 @@
 							"default": true,
 							"description": "Show the documentation code actions."
 						}
-					}
+					},
+					"additionalProperties": false
 				},
 				"eslint.codeActionsOnSave.mode": {
 					"scope": "resource",


### PR DESCRIPTION
As per: https://github.com/microsoft/vscode-eslint/blob/af8bc9924a35e2adf876dc8c4af0467f390945e9/server/src/eslintServer.ts#L157-L163

It looks like `eslint.codeAction.disableRuleComment` and `eslint.codeAction.showDocumentation` don't have any other properties. We should set `additionalProperties: false` in this case.