### PR TITLE
Treat all files with an `eslintignore` extension as ignore files

### DIFF
--- a/package.json
+++ b/package.json
@@ -419,7 +419,7 @@
 		"languages": [
 			{
 				"id": "ignore",
-				"filenames": [
+				"extensions": [
 					".eslintignore"
 				]
 			},


### PR DESCRIPTION
Fixes #1024