### PR TITLE
support remote development by indicating this is a workspace-only extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
 	"activationEvents": [
 		"onStartupFinished"
 	],
+	"extensionKind": [
+		"workspace"
+	],
 	"main": "./client/out/extension",
 	"contributes": {
 		"configuration": {


### PR DESCRIPTION
See docs: https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location