### PR TITLE
Implement eslint.rules.customizations - with overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This extension contributes the following variables to the [settings](https://cod
 - `eslint.rules.customizations`: force rules to report a different severity within VS Code compared to the project's true ESLint configuration. contain two properties:
   - `"rule`": Select on rules with names that match, factoring in asterisks as wildcards: `{ "rule": "no-*", "severity": "warn" }`
     - Prefix the query with a `"!"` to target all rules that _don't_ match the query: `{ "rule": "!no-*", "severity": "info" }`
-  - `"severity"`: Sets a new severity for matched rule(s), `"downgrade"`s them to a lower severity, `"upgrade"`s them to a higher severity, or `"reset"`s them to their original severity
+  - `"severity"`: Sets a new severity for matched rule(s), `"downgrade"`s them to a lower severity, `"upgrade"`s them to a higher severity, or `"default"`s them to their original severity
 
   In this example, all rules are overridden to warnings:
 
@@ -159,13 +159,13 @@ This extension contributes the following variables to the [settings](https://cod
   ]
   ```
 
-  In this example, `no-` rules are informative, other rules are downgraded, and `"radix"` is reset:
+  In this example, `no-` rules are informative, other rules are downgraded, and `"radix"` is reset to default:
 
   ```json
   "eslint.rules.customizations": [
     { "rule": "no-*", "severity": "info" },
     { "rule": "!no-*", "severity": "downgrade" },
-    { "rule": "radix", "severity": "reset" }
+    { "rule": "radix", "severity": "default" }
   ]
   ```
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ This extension contributes the following variables to the [settings](https://cod
   - `all`: fixes all possible problems by revalidating the file's content. This executes the same code path as running eslint with the `--fix` option in the terminal and therefore can take some time. This is the default value.
   - `problems`: fixes only the currently known fixable problems as long as their textual edits are non overlapping. This mode is a lot faster but very likely only fixes parts of the problems.
 
-- `eslint.rules.customizations`: force rules to report a different severity within VS Code compared to the project's true ESLint configuration. contain two properties:
+- `eslint.rules.customizations` (@since 2.1.20): force rules to report a different severity within VS Code compared to the project's true ESLint configuration. Contains two properties:
   - `"rule`": Select on rules with names that match, factoring in asterisks as wildcards: `{ "rule": "no-*", "severity": "warn" }`
-    - Prefix the query with a `"!"` to target all rules that _don't_ match the query: `{ "rule": "!no-*", "severity": "info" }`
+    - Prefix the name with a `"!"` to target all rules that _don't_ match the name: `{ "rule": "!no-*", "severity": "info" }`
   - `"severity"`: Sets a new severity for matched rule(s), `"downgrade"`s them to a lower severity, `"upgrade"`s them to a higher severity, or `"default"`s them to their original severity
 
   In this example, all rules are overridden to warnings:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This extension contributes the following variables to the [settings](https://cod
 
 - `eslint.rules.customizations`: force rules to report a different severity within VS Code compared to the project's true ESLint configuration. This is an array that allows two kinds of glob patterns:
   - `"override`": Overrides for rules with names that match, factoring in asterisks: `{ "override": "no-*", "severity": "warn" }`
-  - `"ignore"`: Excludes rules matching a glob from previous overrides: `{ "ignore": "*jsx*" }`
+  - `"reset"`: Excludes rules matching a glob from previous overrides: `{ "reset": "*jsx*" }`
 
   In this example, all rules are overridden to warnings:
 
@@ -164,8 +164,8 @@ This extension contributes the following variables to the [settings](https://cod
   "eslint.rules.customizations": [
     { "override": "*", "severity": "warn" },
     { "override": "no-*", "severity": "info" },
-    { "ignore": "*semi*" },
-    { "ignore": "radix" }
+    { "reset": "*semi*" },
+    { "reset": "radix" }
   ]
   ```
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ This extension contributes the following variables to the [settings](https://cod
   - `all`: fixes all possible problems by revalidating the file's content. This executes the same code path as running eslint with the `--fix` option in the terminal and therefore can take some time. This is the default value.
   - `problems`: fixes only the currently known fixable problems as long as their textual edits are non overlapping. This mode is a lot faster but very likely only fixes parts of the problems.
 
-- `eslint.rules.customizations`: force rules to report a different severity within VS Code compared to the project's true ESLint configuration. This is an array that allows two kinds of glob patterns:
-  - `"override`": Overrides for rules with names that match, factoring in asterisks: `{ "override": "no-*", "severity": "warn" }`
-  - `"reset"`: Excludes rules matching a glob from previous overrides: `{ "reset": "*jsx*" }`
+- `eslint.rules.customizations`: force rules to report a different severity within VS Code compared to the project's true ESLint configuration. contain two properties:
+  - `"rule`": Select on rules with names that match, factoring in asterisks as wildcards: `{ "override": "no-*", "severity": "warn" }`
+    - Prefix the query with a `"!"` to target all rules that _don't_ match the query: `{ "override": "!no-*", "severity": "info" }`
+  - `"override"`: Sets a new severity for matched rule(s), `"downgrade"`s them to a lower severity, `"upgrade"`s them to a higher severity, or `"reset"`s them to their original severity
 
   In this example, all rules are overridden to warnings:
 
@@ -158,14 +159,13 @@ This extension contributes the following variables to the [settings](https://cod
   ]
   ```
 
-  In this example, with the exception of `semi` rules and `radix`, all all `no-` rules are warnings and other rules are info:
+  In this example, `no-` rules are informative, other rules are downgraded, and `"radix"` is reset:
 
   ```json
   "eslint.rules.customizations": [
-    { "override": "*", "severity": "warn" },
     { "override": "no-*", "severity": "info" },
-    { "reset": "*semi*" },
-    { "reset": "radix" }
+    { "override": "!no-*", "severity": "downgrade" },
+    { "reset": "radix", "severity": "reset" }
   ]
   ```
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,29 @@ This extension contributes the following variables to the [settings](https://cod
   - `all`: fixes all possible problems by revalidating the file's content. This executes the same code path as running eslint with the `--fix` option in the terminal and therefore can take some time. This is the default value.
   - `problems`: fixes only the currently known fixable problems as long as their textual edits are non overlapping. This mode is a lot faster but very likely only fixes parts of the problems.
 
+- `eslint.rules.customizations`: force rules to report a different severity within VS Code compared to the project's true ESLint configuration. This is an array that allows two kinds of glob patterns:
+  - `"override`": Overrides for rules with names that match, factoring in asterisks: `{ "override": "no-*", "severity": "warn" }`
+  - `"ignore"`: Excludes rules matching a glob from previous overrides: `{ "ignore": "*jsx*" }`
+
+  In this example, all rules are overridden to warnings:
+
+  ```json
+  "eslint.rules.customizations": [
+    { "override": "*", "severity": "warn" }
+  ]
+  ```
+
+  In this example, with the exception of `semi` rules and `radix`, all all `no-` rules are warnings and other rules are info:
+
+  ```json
+  "eslint.rules.customizations": [
+    { "override": "*", "severity": "warn" },
+    { "override": "no-*", "severity": "info" },
+    { "ignore": "*semi*" },
+    { "ignore": "radix" }
+  ]
+  ```
+
 - `eslint.format.enable` (@since 2.0.0): uses ESlint as a formatter for files that are validated by ESLint. If enabled please ensure to disable other formatters if you want to make this the default. A good way to do so is to add the following setting `"[javascript]": { "editor.defaultFormatter": "dbaeumer.vscode-eslint" }` for JavaScript. For TypeScript you need to add `"[typescript]": { "editor.defaultFormatter": "dbaeumer.vscode-eslint" }`.
 - `eslint.onIgnoredFiles` (@since 2.0.10): used to control whether warnings should be generated when trying to lint ignored files. Default is `off`. Can be set to `warn`.
 - `editor.codeActionsOnSave` (@since 2.0.0): this setting now supports an entry `source.fixAll.eslint`. If set to true all auto-fixable ESLint errors from all plugins will be fixed on save. You can also selectively enable and disabled specific languages using VS Code's language scoped settings. To disable `codeActionsOnSave` for HTML files use the following setting:

--- a/README.md
+++ b/README.md
@@ -147,15 +147,15 @@ This extension contributes the following variables to the [settings](https://cod
   - `problems`: fixes only the currently known fixable problems as long as their textual edits are non overlapping. This mode is a lot faster but very likely only fixes parts of the problems.
 
 - `eslint.rules.customizations`: force rules to report a different severity within VS Code compared to the project's true ESLint configuration. contain two properties:
-  - `"rule`": Select on rules with names that match, factoring in asterisks as wildcards: `{ "override": "no-*", "severity": "warn" }`
-    - Prefix the query with a `"!"` to target all rules that _don't_ match the query: `{ "override": "!no-*", "severity": "info" }`
-  - `"override"`: Sets a new severity for matched rule(s), `"downgrade"`s them to a lower severity, `"upgrade"`s them to a higher severity, or `"reset"`s them to their original severity
+  - `"rule`": Select on rules with names that match, factoring in asterisks as wildcards: `{ "rule": "no-*", "severity": "warn" }`
+    - Prefix the query with a `"!"` to target all rules that _don't_ match the query: `{ "rule": "!no-*", "severity": "info" }`
+  - `"severity"`: Sets a new severity for matched rule(s), `"downgrade"`s them to a lower severity, `"upgrade"`s them to a higher severity, or `"reset"`s them to their original severity
 
   In this example, all rules are overridden to warnings:
 
   ```json
   "eslint.rules.customizations": [
-    { "override": "*", "severity": "warn" }
+    { "rule": "*", "severity": "warn" }
   ]
   ```
 
@@ -163,9 +163,9 @@ This extension contributes the following variables to the [settings](https://cod
 
   ```json
   "eslint.rules.customizations": [
-    { "override": "no-*", "severity": "info" },
-    { "override": "!no-*", "severity": "downgrade" },
-    { "reset": "radix", "severity": "reset" }
+    { "rule": "no-*", "severity": "info" },
+    { "rule": "!no-*", "severity": "downgrade" },
+    { "rule": "radix", "severity": "reset" }
   ]
   ```
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -188,7 +188,7 @@ enum RuleSeverity {
 	error = 'error',
 
 	// Added severity override changes
-	reset = 'reset',
+	default = 'default',
 	downgrade = 'downgrade',
 	upgrade = 'upgrade'
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -423,7 +423,7 @@ function parseRulesCustomizations(rawConfig: unknown): RuleCustomization[] {
 	}
 
 	return rawConfig.map(rawValue => {
-		if ('severity' in rawValue && typeof rawValue.severity === 'string' && 'rule' in rawValue && typeof rawValue.rule === 'string') {
+		if (typeof rawValue.severity === 'string' && typeof rawValue.rule === 'string') {
 			return {
 				severity: rawValue.severity,
 				rule: rawValue.rule,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -187,7 +187,7 @@ enum RuleSeverity {
 	warn = 'warn',
 	error = 'error',
 
-	// Added override changes
+	// Added severity override changes
 	reset = 'reset',
 	downgrade = 'downgrade',
 	upgrade = 'upgrade'
@@ -195,7 +195,7 @@ enum RuleSeverity {
 
 interface RuleCustomization  {
 	rule: string;
-	override: RuleSeverity;
+	severity: RuleSeverity;
 }
 
 interface ConfigurationSettings {
@@ -423,9 +423,9 @@ function parseRulesCustomizations(rawConfig: unknown): RuleCustomization[] {
 	}
 
 	return rawConfig.map(rawValue => {
-		if ('override' in rawValue && typeof rawValue.override === 'string' && 'rule' in rawValue && typeof rawValue.rule === 'string') {
+		if ('severity' in rawValue && typeof rawValue.severity === 'string' && 'rule' in rawValue && typeof rawValue.rule === 'string') {
 			return {
-				override: rawValue.override,
+				severity: rawValue.severity,
 				rule: rawValue.rule,
 			};
 		}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -187,10 +187,10 @@ enum RuleSeverity {
 	error = 'error'
 }
 
-type RuleCustomization = RuleIgnore | RuleOverride;
+type RuleCustomization = RuleOverride | RuleReset;
 
-interface RuleIgnore {
-	ignore: string;
+interface RuleReset {
+	reset: string;
 }
 
 interface RuleOverride {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -181,15 +181,21 @@ enum ConfirmationSelection {
 	alwaysAllow = 4
 }
 
-type RuleCustomization = RuleOverride | RuleReset;
+enum RuleSeverity {
+	// Original ESLint values
+	info = 'info',
+	warn = 'warn',
+	error = 'error',
 
-interface RuleReset {
-	reset: string;
+	// Added override changes
+	reset = 'reset',
+	downgrade = 'downgrade',
+	upgrade = 'upgrade'
 }
 
-interface RuleOverride {
-	override: string;
-	severity: ESLintSeverity;
+interface RuleCustomization  {
+	rule: string;
+	override: RuleSeverity;
 }
 
 interface ConfigurationSettings {
@@ -411,20 +417,16 @@ function computeValidate(textDocument: TextDocument): Validate {
 	return Validate.off;
 }
 
-function parseRulesCustomizations(rawConfig: Partial<RuleCustomization>[] | unknown): RuleCustomization[] {
+function parseRulesCustomizations(rawConfig: unknown): RuleCustomization[] {
 	if (!rawConfig || !Array.isArray(rawConfig)) {
 		return [];
 	}
 
 	return rawConfig.map(rawValue => {
-		if ('reset' in rawValue && typeof rawValue.reset === 'string') {
-			return { reset: rawValue.reset };
-		}
-
-		if ('override' in rawValue && typeof rawValue.override === 'string' && 'severity' in rawValue && typeof rawValue.severity === 'string') {
+		if ('override' in rawValue && typeof rawValue.override === 'string' && 'rule' in rawValue && typeof rawValue.rule === 'string') {
 			return {
 				override: rawValue.override,
-				severity: rawValue.severity,
+				rule: rawValue.rule,
 			};
 		}
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -181,6 +181,23 @@ enum ConfirmationSelection {
 	alwaysAllow = 4
 }
 
+enum RuleSeverity {
+	info = 'info',
+	warn = 'warn',
+	error = 'error'
+}
+
+type RuleCustomization = RuleIgnore | RuleOverride;
+
+interface RuleIgnore {
+	ignore: string;
+}
+
+interface RuleOverride {
+	override: string;
+	severity: RuleSeverity;
+}
+
 interface ConfigurationSettings {
 	validate: Validate;
 	packageManager: 'npm' | 'yarn' | 'pnpm';
@@ -190,6 +207,7 @@ interface ConfigurationSettings {
 	quiet: boolean;
 	onIgnoredFiles: ESLintSeverity;
 	options: any | undefined;
+	rulesCustomizations: RuleCustomization[];
 	run: RunValues;
 	nodePath: string | null;
 	workspaceFolder: WorkspaceFolder | undefined;
@@ -1441,6 +1459,7 @@ function realActivate(context: ExtensionContext): void {
 							quiet: config.get('quiet', false),
 							onIgnoredFiles: ESLintSeverity.from(config.get<string>('onIgnoredFiles', ESLintSeverity.off)),
 							options: config.get('options', {}),
+							rulesCustomizations: config.get('rules.customizations', []),
 							run: config.get('run', 'onType'),
 							nodePath: config.get('nodePath', null),
 							workingDirectory: undefined,

--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
 					"description": "Override the severity of one or more rules reported by this extension, regardless of the project's ESLint config. Use globs to apply default severities for multiple rules.",
 					"items": {
 						"properties": {
-							"override": {
+							"severity": {
 								"enum": [
 									"downgrade",
 									"error",

--- a/package.json
+++ b/package.json
@@ -380,45 +380,25 @@
 					"description": "Override the severity of one or more rules reported by this extension, regardless of the project's ESLint config. Use globs to apply default severities for multiple rules.",
 					"items": {
 						"properties": {
-							"anyOf": [
-								{
-									"properties": {
-										"severity": {
-											"type": "string",
-											"enum": [
-												"off",
-												"messages",
-												"verbose"
-											]
-										},
-										"override": {
-											"type": "string"
-										}
-									},
-									"type": "object"
-								},
-								{
-									"properties": {
-										"reset": {
-											"type": "string"
-										}
-									},
-									"type": "object"
-								}
-							]
+							"override": {
+								"enum": [
+									"downgrade",
+									"error",
+									"info",
+									"reset",
+									"upgrade",
+									"warn"
+								],
+								"type": "string"
+							},
+							"rule": {
+								"type": "string"
+							}
 						},
 						"type": "object"
 					},
 					"scope": "resource",
-					"type": "array",
-					"additionalProperties": {
-						"type": "string",
-						"enum": [
-							"info",
-							"warn",
-							"error"
-						]
-					}
+					"type": "array"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -375,6 +375,50 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Enables ESLint as a formatter."
+				},
+				"eslint.rules.customizations": {
+					"description": "Override the severity of one or more rules reported by this extension, regardless of the project's ESLint config. Use globs to apply default severities for multiple rules.",
+					"items": {
+						"properties": {
+							"anyOf": [
+								{
+									"properties": {
+										"ignore": {
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								{
+									"properties": {
+										"severity": {
+											"type": "string",
+											"enum": [
+												"off",
+												"messages",
+												"verbose"
+											]
+										},
+										"rule": {
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							]
+						},
+						"type": "object"
+					},
+					"scope": "resource",
+					"type": "array",
+					"additionalProperties": {
+						"type": "string",
+						"enum": [
+							"info",
+							"warn",
+							"error"
+						]
+					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -404,7 +404,7 @@
 										}
 									},
 									"type": "object"
-								},
+								}
 							]
 						},
 						"type": "object"

--- a/package.json
+++ b/package.json
@@ -383,14 +383,6 @@
 							"anyOf": [
 								{
 									"properties": {
-										"ignore": {
-											"type": "string"
-										}
-									},
-									"type": "object"
-								},
-								{
-									"properties": {
 										"severity": {
 											"type": "string",
 											"enum": [
@@ -399,12 +391,20 @@
 												"verbose"
 											]
 										},
-										"rule": {
+										"override": {
 											"type": "string"
 										}
 									},
 									"type": "object"
-								}
+								},
+								{
+									"properties": {
+										"reset": {
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
 							]
 						},
 						"type": "object"

--- a/package.json
+++ b/package.json
@@ -385,7 +385,7 @@
 									"downgrade",
 									"error",
 									"info",
-									"reset",
+									"default",
 									"upgrade",
 									"warn"
 								],

--- a/playgrounds/6.0/.vscode/settings.json
+++ b/playgrounds/6.0/.vscode/settings.json
@@ -39,6 +39,13 @@
 		"location": "separateLine"
 	},
 	"eslint.quiet": false,
+	"eslint.rules.customizations": [
+		{ "override": "*", "severity": "info" },
+		{ "override": "no-*", "severity": "warn" },
+		{ "ignore": "*console*" },
+		{ "ignore": "*semi*" },
+		{ "ignore": "radix" }
+	],
 	"editor.codeActionsOnSaveTimeout": 2000,
 	"eslint.format.enable": true,
 	"eslint.onIgnoredFiles": "off",

--- a/playgrounds/6.0/.vscode/settings.json
+++ b/playgrounds/6.0/.vscode/settings.json
@@ -43,8 +43,8 @@
 		{ "rule": "*", "severity": "error" },
 		{ "rule": "!no-*", "severity": "upgrade" },
 		{ "rule": "*console*", "severity": "upgrade" },
-		{ "rule": "*semi*", "severity": "reset" },
-		{ "rule": "radix", "severity": "reset" }
+		{ "rule": "*semi*", "severity": "default" },
+		{ "rule": "radix", "severity": "default" }
 	],
 	"editor.codeActionsOnSaveTimeout": 2000,
 	"eslint.format.enable": true,

--- a/playgrounds/6.0/.vscode/settings.json
+++ b/playgrounds/6.0/.vscode/settings.json
@@ -40,11 +40,11 @@
 	},
 	"eslint.quiet": false,
 	"eslint.rules.customizations": [
-		{ "rule": "*", "override": "info" },
-		{ "rule": "!no-*", "override": "downgrade" },
-		{ "rule": "*console*", "override": "upgrade" },
-		{ "rule": "*semi*", "override": "reset" },
-		{ "rule": "radix", "override": "reset" }
+		{ "rule": "*", "severity": "error" },
+		{ "rule": "!no-*", "severity": "upgrade" },
+		{ "rule": "*console*", "severity": "upgrade" },
+		{ "rule": "*semi*", "severity": "reset" },
+		{ "rule": "radix", "severity": "reset" }
 	],
 	"editor.codeActionsOnSaveTimeout": 2000,
 	"eslint.format.enable": true,

--- a/playgrounds/6.0/.vscode/settings.json
+++ b/playgrounds/6.0/.vscode/settings.json
@@ -42,9 +42,9 @@
 	"eslint.rules.customizations": [
 		{ "override": "*", "severity": "info" },
 		{ "override": "no-*", "severity": "warn" },
-		{ "ignore": "*console*" },
-		{ "ignore": "*semi*" },
-		{ "ignore": "radix" }
+		{ "reset": "*console*" },
+		{ "reset": "*semi*" },
+		{ "reset": "radix" }
 	],
 	"editor.codeActionsOnSaveTimeout": 2000,
 	"eslint.format.enable": true,

--- a/playgrounds/6.0/.vscode/settings.json
+++ b/playgrounds/6.0/.vscode/settings.json
@@ -40,11 +40,11 @@
 	},
 	"eslint.quiet": false,
 	"eslint.rules.customizations": [
-		{ "override": "*", "severity": "info" },
-		{ "override": "no-*", "severity": "warn" },
-		{ "reset": "*console*" },
-		{ "reset": "*semi*" },
-		{ "reset": "radix" }
+		{ "rule": "*", "override": "info" },
+		{ "rule": "!no-*", "override": "downgrade" },
+		{ "rule": "*console*", "override": "upgrade" },
+		{ "rule": "*semi*", "override": "reset" },
+		{ "rule": "radix", "override": "reset" }
 	],
 	"editor.codeActionsOnSaveTimeout": 2000,
 	"eslint.format.enable": true,

--- a/playgrounds/6.0/test.js
+++ b/playgrounds/6.0/test.js
@@ -3,6 +3,7 @@ function bar() {
 		let str = 'hallo';
 		foo(str);
 	}
+	console.log("aha!");
 }
 
 function foo(str) {

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -230,10 +230,10 @@ enum RuleSeverity {
 	error = 'error'
 }
 
-type RuleCustomization = RuleIgnore | RuleOverride;
+type RuleCustomization = RuleOverride | RuleReset;
 
-interface RuleIgnore {
-	ignore: string;
+interface RuleReset {
+	reset: string;
 }
 
 interface RuleOverride {
@@ -394,12 +394,12 @@ function getSeverityOverride(ruleId: string, customizations: RuleCustomization[]
 	let result: RuleSeverity | undefined;
 
 	for (const customization of customizations) {
-		if ('ignore' in customization) {
-			if (asteriskMatches(customization.ignore, ruleId)) {
-				result = undefined;
+		if ('override' in customization) {
+			if (asteriskMatches(customization.override, ruleId)) {
+				result = customization.severity;
 			}
-		} else if (asteriskMatches(customization.override, ruleId)) {
-			result = customization.severity;
+		} else if (asteriskMatches(customization.reset, ruleId)) {
+			result = undefined;
 		}
 	}
 
@@ -1365,7 +1365,7 @@ function validate(document: TextDocument, settings: TextDocumentSettings & { lib
 							// Filter out warnings when quiet mode is enabled
 							return;
 						}
-						const diagnostic = makeDiagnostic(problem);
+						const diagnostic = makeDiagnostic(settings, problem);
 						diagnostics.push(diagnostic);
 						if (fixTypes !== undefined && CLIEngine.hasRule(cli) && problem.ruleId !== undefined && problem.fix !== undefined) {
 							const rule = cli.getRules().get(problem.ruleId);

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -231,16 +231,16 @@ enum RuleSeverity {
 	warn = 'warn',
 	error = 'error',
 
-	// Added override changes
+	// Added severity override changes
 	off = 'off',
-	reset = 'reset',
+	default = 'default',
 	downgrade = 'downgrade',
 	upgrade = 'upgrade'
 }
 
 interface RuleCustomization  {
 	rule: string;
-	override: RuleSeverity;
+	severity: RuleSeverity;
 }
 
 interface CommonSettings {
@@ -406,7 +406,7 @@ function getSeverityOverride(ruleId: string, customizations: RuleCustomization[]
 
 	for (const customization of customizations) {
 		if (asteriskMatches(customization.rule, ruleId)) {
-			result = customization.override;
+			result = customization.severity;
 		}
 	}
 

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -23,6 +23,7 @@ import * as fs from 'fs';
 import { execSync } from 'child_process';
 import { EOL } from 'os';
 import { stringDiff } from './diff';
+import { LinkedMap } from './linkedMap';
 
 namespace Is {
 	const toString = Object.prototype.toString;
@@ -386,7 +387,7 @@ function loadNodeModule<T>(moduleName: string): T | undefined {
 	return undefined;
 }
 
-type RuleSeverityCache = Map<string, RuleSeverity | undefined>;
+type RuleSeverityCache = LinkedMap<string, RuleSeverity | undefined>;
 
 function asteriskMatches(matcher: string, ruleId: string) {
 	return new RegExp(`^${matcher.replace(/\*/g, '.*')}$`, 'g').test(ruleId);
@@ -1330,7 +1331,7 @@ const ruleDocData: {
 	urls: new Map<string, string>()
 };
 
-const ruleSeverityCache: RuleSeverityCache = new Map();
+const ruleSeverityCache: RuleSeverityCache = new LinkedMap();
 let ruleCustomizationsKey: string | undefined;
 
 const validFixTypes = new Set<string>(['problem', 'suggestion', 'layout']);

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1330,6 +1330,8 @@ const ruleDocData: {
 	urls: new Map<string, string>()
 };
 
+const ruleSeverityCache: RuleSeverityCache = new Map();
+let ruleCustomizationsKey: string | undefined;
 
 const validFixTypes = new Set<string>(['problem', 'suggestion', 'layout']);
 function validate(document: TextDocument, settings: TextDocumentSettings & { library: ESLintModule }, publishDiagnostics: boolean = true): void {
@@ -1347,10 +1349,15 @@ function validate(document: TextDocument, settings: TextDocumentSettings & { lib
 		}
 	}
 
+	const newRuleCustomizationsKey = JSON.stringify(settings.rulesCustomizations);
+	if (ruleCustomizationsKey !== newRuleCustomizationsKey) {
+		ruleCustomizationsKey = newRuleCustomizationsKey;
+		ruleSeverityCache.clear();
+	}
+
 	const content = document.getText();
 	const uri = document.uri;
 	const file = getFilePath(document);
-	const ruleSeverityCache: RuleSeverityCache = new Map();
 
 	withCLIEngine((cli) => {
 		codeActions.delete(uri);

--- a/server/src/linkedMap.ts
+++ b/server/src/linkedMap.ts
@@ -1,0 +1,448 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+interface Item<K, V> {
+	previous: Item<K, V> | undefined;
+	next: Item<K, V> | undefined;
+	key: K;
+	value: V;
+}
+
+export namespace Touch {
+	export const None: 0 = 0;
+	export const First: 1 = 1;
+	export const AsOld: 1 = Touch.First;
+	export const Last: 2 = 2;
+	export const AsNew: 2 = Touch.Last;
+}
+
+export type Touch = 0 | 1 | 2;
+
+export class LinkedMap<K, V> implements Map<K, V> {
+
+	readonly [Symbol.toStringTag] = 'LinkedMap';
+
+	private _map: Map<K, Item<K, V>>;
+	private _head: Item<K, V> | undefined;
+	private _tail: Item<K, V> | undefined;
+	private _size: number;
+
+	private _state: number;
+
+	public constructor() {
+		this._map = new Map<K, Item<K, V>>();
+		this._head = undefined;
+		this._tail = undefined;
+		this._size = 0;
+		this._state = 0;
+	}
+
+	public clear(): void {
+		this._map.clear();
+		this._head = undefined;
+		this._tail = undefined;
+		this._size = 0;
+		this._state++;
+	}
+
+	public isEmpty(): boolean {
+		return !this._head && !this._tail;
+	}
+
+	public get size(): number {
+		return this._size;
+	}
+
+	public get first(): V | undefined {
+		return this._head?.value;
+	}
+
+	public get last(): V | undefined {
+		return this._tail?.value;
+	}
+
+	public has(key: K): boolean {
+		return this._map.has(key);
+	}
+
+	public get(key: K, touch: Touch = Touch.None): V | undefined {
+		const item = this._map.get(key);
+		if (!item) {
+			return undefined;
+		}
+		if (touch !== Touch.None) {
+			this.touch(item, touch);
+		}
+		return item.value;
+	}
+
+	public set(key: K, value: V, touch: Touch = Touch.None): this {
+		let item = this._map.get(key);
+		if (item) {
+			item.value = value;
+			if (touch !== Touch.None) {
+				this.touch(item, touch);
+			}
+		} else {
+			item = { key, value, next: undefined, previous: undefined };
+			switch (touch) {
+				case Touch.None:
+					this.addItemLast(item);
+					break;
+				case Touch.First:
+					this.addItemFirst(item);
+					break;
+				case Touch.Last:
+					this.addItemLast(item);
+					break;
+				default:
+					this.addItemLast(item);
+					break;
+			}
+			this._map.set(key, item);
+			this._size++;
+		}
+		return this;
+	}
+
+	public delete(key: K): boolean {
+		return !!this.remove(key);
+	}
+
+	public remove(key: K): V | undefined {
+		const item = this._map.get(key);
+		if (!item) {
+			return undefined;
+		}
+		this._map.delete(key);
+		this.removeItem(item);
+		this._size--;
+		return item.value;
+	}
+
+	public shift(): V | undefined {
+		if (!this._head && !this._tail) {
+			return undefined;
+		}
+		if (!this._head || !this._tail) {
+			throw new Error('Invalid list');
+		}
+		const item = this._head;
+		this._map.delete(item.key);
+		this.removeItem(item);
+		this._size--;
+		return item.value;
+	}
+
+	public forEach(callbackfn: (value: V, key: K, map: LinkedMap<K, V>) => void, thisArg?: any): void {
+		const state = this._state;
+		let current = this._head;
+		while (current) {
+			if (thisArg) {
+				callbackfn.bind(thisArg)(current.value, current.key, this);
+			} else {
+				callbackfn(current.value, current.key, this);
+			}
+			if (this._state !== state) {
+				throw new Error(`LinkedMap got modified during iteration.`);
+			}
+			current = current.next;
+		}
+	}
+
+	public keys(): IterableIterator<K> {
+		const map = this;
+		const state = this._state;
+		let current = this._head;
+		const iterator: IterableIterator<K> = {
+			[Symbol.iterator]() {
+				return iterator;
+			},
+			next(): IteratorResult<K> {
+				if (map._state !== state) {
+					throw new Error(`LinkedMap got modified during iteration.`);
+				}
+				if (current) {
+					const result = { value: current.key, done: false };
+					current = current.next;
+					return result;
+				} else {
+					return { value: undefined, done: true };
+				}
+			}
+		};
+		return iterator;
+	}
+
+	public values(): IterableIterator<V> {
+		const map = this;
+		const state = this._state;
+		let current = this._head;
+		const iterator: IterableIterator<V> = {
+			[Symbol.iterator]() {
+				return iterator;
+			},
+			next(): IteratorResult<V> {
+				if (map._state !== state) {
+					throw new Error(`LinkedMap got modified during iteration.`);
+				}
+				if (current) {
+					const result = { value: current.value, done: false };
+					current = current.next;
+					return result;
+				} else {
+					return { value: undefined, done: true };
+				}
+			}
+		};
+		return iterator;
+	}
+
+	public entries(): IterableIterator<[K, V]> {
+		const map = this;
+		const state = this._state;
+		let current = this._head;
+		const iterator: IterableIterator<[K, V]> = {
+			[Symbol.iterator]() {
+				return iterator;
+			},
+			next(): IteratorResult<[K, V]> {
+				if (map._state !== state) {
+					throw new Error(`LinkedMap got modified during iteration.`);
+				}
+				if (current) {
+					const result: IteratorResult<[K, V]> = { value: [current.key, current.value], done: false };
+					current = current.next;
+					return result;
+				} else {
+					return { value: undefined, done: true };
+				}
+			}
+		};
+		return iterator;
+	}
+
+	public [Symbol.iterator](): IterableIterator<[K, V]> {
+		return this.entries();
+	}
+
+	protected trimOld(newSize: number) {
+		if (newSize >= this.size) {
+			return;
+		}
+		if (newSize === 0) {
+			this.clear();
+			return;
+		}
+		let current = this._head;
+		let currentSize = this.size;
+		while (current && currentSize > newSize) {
+			this._map.delete(current.key);
+			current = current.next;
+			currentSize--;
+		}
+		this._head = current;
+		this._size = currentSize;
+		if (current) {
+			current.previous = undefined;
+		}
+		this._state++;
+	}
+
+	private addItemFirst(item: Item<K, V>): void {
+		// First time Insert
+		if (!this._head && !this._tail) {
+			this._tail = item;
+		} else if (!this._head) {
+			throw new Error('Invalid list');
+		} else {
+			item.next = this._head;
+			this._head.previous = item;
+		}
+		this._head = item;
+		this._state++;
+	}
+
+	private addItemLast(item: Item<K, V>): void {
+		// First time Insert
+		if (!this._head && !this._tail) {
+			this._head = item;
+		} else if (!this._tail) {
+			throw new Error('Invalid list');
+		} else {
+			item.previous = this._tail;
+			this._tail.next = item;
+		}
+		this._tail = item;
+		this._state++;
+	}
+
+	private removeItem(item: Item<K, V>): void {
+		if (item === this._head && item === this._tail) {
+			this._head = undefined;
+			this._tail = undefined;
+		}
+		else if (item === this._head) {
+			// This can only happend if size === 1 which is handle
+			// by the case above.
+			if (!item.next) {
+				throw new Error('Invalid list');
+			}
+			item.next.previous = undefined;
+			this._head = item.next;
+		}
+		else if (item === this._tail) {
+			// This can only happend if size === 1 which is handle
+			// by the case above.
+			if (!item.previous) {
+				throw new Error('Invalid list');
+			}
+			item.previous.next = undefined;
+			this._tail = item.previous;
+		}
+		else {
+			const next = item.next;
+			const previous = item.previous;
+			if (!next || !previous) {
+				throw new Error('Invalid list');
+			}
+			next.previous = previous;
+			previous.next = next;
+		}
+		item.next = undefined;
+		item.previous = undefined;
+		this._state++;
+	}
+
+	private touch(item: Item<K, V>, touch: Touch): void {
+		if (!this._head || !this._tail) {
+			throw new Error('Invalid list');
+		}
+		if ((touch !== Touch.First && touch !== Touch.Last)) {
+			return;
+		}
+
+		if (touch === Touch.First) {
+			if (item === this._head) {
+				return;
+			}
+
+			const next = item.next;
+			const previous = item.previous;
+
+			// Unlink the item
+			if (item === this._tail) {
+				// previous must be defined since item was not head but is tail
+				// So there are more than on item in the map
+				previous!.next = undefined;
+				this._tail = previous;
+			}
+			else {
+				// Both next and previous are not undefined since item was neither head nor tail.
+				next!.previous = previous;
+				previous!.next = next;
+			}
+
+			// Insert the node at head
+			item.previous = undefined;
+			item.next = this._head;
+			this._head.previous = item;
+			this._head = item;
+			this._state++;
+		} else if (touch === Touch.Last) {
+			if (item === this._tail) {
+				return;
+			}
+
+			const next = item.next;
+			const previous = item.previous;
+
+			// Unlink the item.
+			if (item === this._head) {
+				// next must be defined since item was not tail but is head
+				// So there are more than on item in the map
+				next!.previous = undefined;
+				this._head = next;
+			} else {
+				// Both next and previous are not undefined since item was neither head nor tail.
+				next!.previous = previous;
+				previous!.next = next;
+			}
+			item.next = undefined;
+			item.previous = this._tail;
+			this._tail.next = item;
+			this._tail = item;
+			this._state++;
+		}
+	}
+
+	public toJSON(): [K, V][] {
+		const data: [K, V][] = [];
+
+		this.forEach((value, key) => {
+			data.push([key, value]);
+		});
+
+		return data;
+	}
+
+	public fromJSON(data: [K, V][]): void {
+		this.clear();
+
+		for (const [key, value] of data) {
+			this.set(key, value);
+		}
+	}
+}
+
+export class LRUCache<K, V> extends LinkedMap<K, V> {
+
+	private _limit: number;
+	private _ratio: number;
+
+	public constructor(limit: number, ratio: number = 1) {
+		super();
+		this._limit = limit;
+		this._ratio = Math.min(Math.max(0, ratio), 1);
+	}
+
+	public get limit(): number {
+		return this._limit;
+	}
+
+	public set limit(limit: number) {
+		this._limit = limit;
+		this.checkTrim();
+	}
+
+	public get ratio(): number {
+		return this._ratio;
+	}
+
+	public set ratio(ratio: number) {
+		this._ratio = Math.min(Math.max(0, ratio), 1);
+		this.checkTrim();
+	}
+
+	public get(key: K, touch: Touch = Touch.AsNew): V | undefined {
+		return super.get(key, touch);
+	}
+
+	public peek(key: K): V | undefined {
+		return super.get(key, Touch.None);
+	}
+
+	public set(key: K, value: V): this {
+		super.set(key, value, Touch.Last);
+		this.checkTrim();
+		return this;
+	}
+
+	private checkTrim() {
+		if (this.size > this._limit) {
+			this.trimOld(Math.round(this._limit * this._ratio));
+		}
+	}
+}


### PR DESCRIPTION
Continues @jamesorlakin's great work from https://github.com/microsoft/vscode-eslint/pull/993, with the changes requested by @dbaeumer to take settings as an array and allow ignoring rules.

Fixes #468 based on the discussions in #561.

Fixes #1199.

In the demo, note the underline under `bar` and `console.log` changing to red (error):

https://user-images.githubusercontent.com/3335181/110977314-0924af00-8330-11eb-8142-79b6fc8e85c9.mov

Co-authored-by: James Lakin <contact@jameslakin.co.uk>