### PR TITLE
refactor(client): replace deprecated fs.exists

### DIFF
--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -7,12 +7,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-function exists(file: string): Promise<boolean> {
-	return new Promise<boolean>((resolve, _reject) => {
-		fs.exists(file, (value) => {
-			resolve(value);
-		});
-	});
+async function exists(file: string): Promise<boolean> {
+	try {
+		await fs.promises.access(file);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export async function findEslint(rootPath: string): Promise<string> {


### PR DESCRIPTION
Fix #1262

Replace deprecated `fs.exists` with `fs.access`.

Tested and confirmed extension is still working:

![2021-03-18 21_09_55- Extension Development Host  - colors ts - vscode-json-languageservice - Visual ](https://user-images.githubusercontent.com/11912225/111609398-5a500980-882e-11eb-88a8-daa74ac748ee.png)
