### PR TITLE
Add severity "off" to eslint.rules.customizations

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -186,6 +186,7 @@ enum RuleSeverity {
 	info = 'info',
 	warn = 'warn',
 	error = 'error',
+	off = 'off',
 
 	// Added severity override changes
 	default = 'default',

--- a/package.json
+++ b/package.json
@@ -389,7 +389,8 @@
 									"info",
 									"default",
 									"upgrade",
-									"warn"
+									"warn",
+									"off"
 								],
 								"type": "string"
 							},

--- a/playgrounds/6.0/.eslintrc.json
+++ b/playgrounds/6.0/.eslintrc.json
@@ -13,6 +13,7 @@
         "sourceType": "module"
     },
     "rules": {
+        "no-use-before-define": "error",
         "no-useless-escape": "error",
         "no-const-assign": "warn",
         "no-this-before-super": "warn",

--- a/playgrounds/6.0/.vscode/settings.json
+++ b/playgrounds/6.0/.vscode/settings.json
@@ -44,7 +44,8 @@
 		{ "rule": "!no-*", "severity": "upgrade" },
 		{ "rule": "*console*", "severity": "upgrade" },
 		{ "rule": "*semi*", "severity": "default" },
-		{ "rule": "radix", "severity": "default" }
+		{ "rule": "radix", "severity": "default" },
+		{ "rule": "no-use-before-define", "severity": "off" }
 	],
 	"editor.codeActionsOnSaveTimeout": 2000,
 	"eslint.format.enable": true,

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -515,6 +515,7 @@ function recordCodeAction(document: TextDocument, diagnostic: Diagnostic, proble
 
 function adjustSeverityForOverride(severity: number | RuleSeverity, severityOverride?: RuleSeverity) {
 	switch (severityOverride) {
+		case RuleSeverity.off:
 		case RuleSeverity.info:
 		case RuleSeverity.warn:
 		case RuleSeverity.error:
@@ -1404,6 +1405,11 @@ function validate(document: TextDocument, settings: TextDocumentSettings & { lib
 			if (docReport.messages && Array.isArray(docReport.messages)) {
 				docReport.messages.forEach((problem) => {
 					if (problem) {
+						const isOff = getSeverityOverride(problem.ruleId, settings.rulesCustomizations) === RuleSeverity.off;
+						if (isOff) {
+							// Filter out rules with severity override to off
+							return;
+						}
 						const isWarning = convertSeverityToDiagnostic(problem.severity) === DiagnosticSeverity.Warning;
 						if (settings.quiet && isWarning) {
 							// Filter out warnings when quiet mode is enabled


### PR DESCRIPTION
This PR adds the value `off` to `eslint.rules.customizations`, allowing the user to disable the report of selected rules in the editor.
