### PR TITLE
Document "node" for system version of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This extension contributes the following variables to the [settings](https://cod
   ```
 - `eslint.run` - run the linter `onSave` or `onType`, default is `onType`.
 - `eslint.quiet` - ignore warnings.
-- `eslint.runtime` - use this setting to set the path of the node runtime to run ESLint under.
+- `eslint.runtime` - use this setting to set the path of the node runtime to run ESLint under. [Use `"node"`](https://github.com/microsoft/vscode-eslint/issues/1233#issuecomment-815521280) if you want to use your default system version of node.
 - `eslint.nodeEnv` - use this setting if an ESLint plugin or configuration needs `process.env.NODE_ENV` to be defined.
 - `eslint.nodePath` - use this setting if an installed ESLint package can't be detected, for example `/myGlobalNodePackages/node_modules`.
 - `eslint.probe` = an array for language identifiers for which the ESLint extension should be activated and should try to validate the file. If validation fails for probed languages the extension says silent. Defaults to `["javascript", "javascriptreact", "typescript", "typescriptreact", "html", "vue", "markdown"]`.


### PR DESCRIPTION
Hi @dbaeumer ! 👋

Documented the trick in https://github.com/microsoft/vscode-eslint/issues/1233#issuecomment-815521280 for using the system version of Node.js