### PR TITLE
add documentFormattingProvider to server capabilities response

### DIFF
--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1262,7 +1262,8 @@ connection.onInitialize((_params, _cancel, progress) => {
 					CommandIds.applyDisableFile,
 					CommandIds.openRuleDoc,
 				]
-			}
+			},
+			documentFormattingProvider: true
 		}
 	};
 });


### PR DESCRIPTION
Hey! Seeing as this LSP does support the `textDocument/formatting` command - I figured we could add it to the server capabilities response. Currently struggling to get neovim's LSP client to recognize the fact that the ESLint LSP server does in fact support formatting - this ought to fix it.