### PR TITLE
Enable custom eslint module path

### DIFF
--- a/client/src/tasks.ts
+++ b/client/src/tasks.ts
@@ -36,15 +36,18 @@ class FolderTaskProvider {
 			return undefined;
 		}
 		try {
-			const command = await findEslint(rootPath);
+			const config = vscode.workspace.getConfiguration('eslint', this._workspaceFolder.uri);
+			const eslintPath= config.get<string>('eslintPath');
+
+			const command = await findEslint(rootPath, eslintPath);
 
 			const kind: EslintTaskDefinition = {
 				type: 'eslint'
 			};
 
 			const options: vscode.ShellExecutionOptions = { cwd: this.workspaceFolder.uri.fsPath };
-			const config = vscode.workspace.getConfiguration('eslint', this._workspaceFolder.uri);
 			const lintTaskOptions= config.get('lintTask.options', '.');
+
 			return new vscode.Task(
 				kind, this.workspaceFolder,
 				'lint whole folder', 'eslint', new vscode.ShellExecution(`${command} ${lintTaskOptions}`, options),

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -15,9 +15,11 @@ function exists(file: string): Promise<boolean> {
 	});
 }
 
-export async function findEslint(rootPath: string): Promise<string> {
+export async function findEslint(rootPath: string, eslintPath?: string): Promise<string> {
 	const platform = process.platform;
-	if (platform === 'win32' && await exists(path.join(rootPath, 'node_modules', '.bin', 'eslint.cmd'))) {
+	if (eslintPath && await exists(eslintPath)) {
+		return eslintPath;
+	} else if (platform === 'win32' && await exists(path.join(rootPath, 'node_modules', '.bin', 'eslint.cmd'))) {
 		return path.join('.', 'node_modules', '.bin', 'eslint.cmd');
 	} else if ((platform === 'linux' || platform === 'darwin') && await exists(path.join(rootPath, 'node_modules', '.bin', 'eslint'))) {
 		return path.join('.', 'node_modules', '.bin', 'eslint');

--- a/package.json
+++ b/package.json
@@ -88,6 +88,15 @@
 					"default": null,
 					"markdownDescription": "A path added to `NODE_PATH` when resolving the eslint module."
 				},
+				"eslint.eslintPath": {
+					"scope": "machine-overridable",
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"markdownDescription": "Path to eslint module."
+				},
 				"eslint.options": {
 					"scope": "resource",
 					"type": "object",


### PR DESCRIPTION
This PR enables a new setting `eslintPath` to allow users to set a custom path where ESLint module is installed. Similar to other plugins approach [prettier-vscode](https://github.com/prettier/prettier-vscode#prettierprettierpath).