### PR TITLE
Added graphql language to ESLint-server comments

### DIFF
--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -963,7 +963,8 @@ const languageId2Config: Map<string, LanguageConfig> = new Map([
 	['html', { ext: 'html', lineComment: '//', blockComment: ['/*', '*/'] }],
 	['vue', { ext: 'vue', lineComment: '//', blockComment: ['/*', '*/'] }],
 	['coffeescript', { ext: 'coffee', lineComment: '#', blockComment: ['###', '###'] }],
-	['yaml', { ext: 'yaml', lineComment: '#', blockComment: ['#', ''] }]
+	['yaml', { ext: 'yaml', lineComment: '#', blockComment: ['#', ''] }],
+	['graphql', { ext: 'graphql', lineComment: '#', blockComment: ['#', ''] }]
 ]);
 
 function getLineComment(languageId: string): string {


### PR DESCRIPTION
Based on @dbaeumer 's changes in: https://github.com/microsoft/vscode-eslint/commit/35f5fb950065e2223cf5911ae7ff2e2a4e1d1ade 
I added `graphql` language to the list of supported languages. This will make a better integration with https://github.com/dotansimha/graphql-eslint 