### PR TITLE
Minor fixes for eslint.codeActionsOnSave.rules mechanism

### DIFF
--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -553,9 +553,10 @@ function isOff(ruleId: string, matchers: string[]): boolean {
 	return true;
 }
 
-async function getSaveRuleConfig(filePath: string, settings: TextDocumentSettings  & { library: ESLintModule }): Promise<SaveRuleConfigItem | undefined> {
-	let result = saveRuleConfigCache.get(filePath);
-	if (result === null) {
+async function getSaveRuleConfig(uri: string, settings: TextDocumentSettings  & { library: ESLintModule }): Promise<SaveRuleConfigItem | undefined> {
+	const filePath = getFilePath(uri);
+	let result = saveRuleConfigCache.get(uri);
+	if (filePath === undefined || result === null) {
 		return undefined;
 	}
 	if (result !== undefined) {
@@ -586,10 +587,10 @@ async function getSaveRuleConfig(filePath: string, settings: TextDocumentSetting
 		return offRules.size > 0 ? { offRules, onRules } : undefined;
 	}, settings);
 	if (result === undefined || result === null) {
-		saveRuleConfigCache.set(filePath, null);
+		saveRuleConfigCache.set(uri, null);
 		return undefined;
 	} else {
-		saveRuleConfigCache.set(filePath, result);
+		saveRuleConfigCache.set(uri, result);
 		return result;
 	}
 }
@@ -2267,7 +2268,7 @@ async function computeAllFixes(identifier: VersionedTextDocumentIdentifier, mode
 		connection.tracer.log(`Computing all fixes took: ${Date.now() - start} ms.`);
 		return result;
 	} else {
-		const saveConfig = filePath !== undefined && mode === AllFixesMode.onSave ? await getSaveRuleConfig(filePath, settings) : undefined;
+		const saveConfig = filePath !== undefined && mode === AllFixesMode.onSave ? await getSaveRuleConfig(uri, settings) : undefined;
 		const offRules = saveConfig?.offRules;
 		const onRules = saveConfig?.onRules;
 		let overrideConfig: Required<ConfigData> | undefined;

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1446,10 +1446,7 @@ function setupDocumentsListeners() {
 		void resolveSettings(event.document).then((settings) => {
 			const uri = event.document.uri;
 			document2Settings.delete(uri);
-			const filePath = getFilePath(uri);
-			if (filePath) {
-				saveRuleConfigCache.delete(filePath);
-			}
+			saveRuleConfigCache.delete(uri);
 			codeActions.delete(uri);
 			const unregister = formatterRegistrations.get(event.document.uri);
 			if (unregister !== undefined) {

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1447,7 +1447,10 @@ function setupDocumentsListeners() {
 		void resolveSettings(event.document).then((settings) => {
 			const uri = event.document.uri;
 			document2Settings.delete(uri);
-			saveRuleConfigCache.delete(uri);
+			const filePath = getFilePath(uri);
+			if (filePath) {
+				saveRuleConfigCache.delete(filePath);
+			}
 			codeActions.delete(uri);
 			const unregister = formatterRegistrations.get(event.document.uri);
 			if (unregister !== undefined) {


### PR DESCRIPTION
Hi @dbaeumer,

I was studying a way to contribute with #1357 and stepped on two small issues: a bug leading to stale entries on `saveRuleConfigCache` object, and behavior different from the documentation when using `eslint.codeActionsOnSave.rules` with ESLint version 8.

The stale cache is being caused by the use of the file URI to delete cache entries when a file is closed, those entries are indexed by the file path, not the URI. This fix only gets the file path from the URI and uses it to delete the cache entries, it was the simplest solution, but maybe using the URI to index cache entries could be a better one?

The behavior problem is because the function `getSaveRuleConfig` always returns undefined if `eslint.useESLintClass == false`, this makes sense to ESLint version 7, but not for version 8 where the class is the only engine available. This fix removes the responsibility of checking whether the class is available or the `eslint.useESLintClass` from the function `getSaveRuleConfig`, and decides if the rules should not be processed by checking if `ESLintClass.isCLIEngine == true`.

Hope that helps,
Eduardo