### PR TITLE
Allow user to ignore server errors.

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -832,18 +832,26 @@ function realActivate(context: ExtensionContext): void {
 		let tooltip: string | undefined;
 		let text: string = 'ESLint';
 		let backgroundColor: ThemeColor | undefined;
+		let foregroundColor: ThemeColor | undefined;
 		switch (status) {
 			case Status.ok:
 				icon = undefined;
+				foregroundColor = new ThemeColor('statusBarItem.foreground');
+				backgroundColor = new ThemeColor('statusBarItem.background');
 				break;
 			case Status.warn:
 				icon = '$(alert)';
+				foregroundColor = new ThemeColor('statusBarItem.warningForeground');
+				backgroundColor = new ThemeColor('statusBarItem.warningBackground');
 				break;
 			case Status.error:
 				icon = '$(issue-opened)';
+				foregroundColor = new ThemeColor('statusBarItem.errorForeground');
+				backgroundColor = new ThemeColor('statusBarItem.errorBackground');
 				break;
 		}
 		statusBarItem.text = icon !== undefined ? `${icon} ${text}` : text;
+		statusBarItem.color = foregroundColor;
 		statusBarItem.backgroundColor = backgroundColor;
 		statusBarItem.tooltip = tooltip ? tooltip : serverRunning === undefined ? starting : serverRunning === true ? running : stopped;
 		const alwaysShow = Workspace.getConfiguration('eslint').get('alwaysShowStatus', false);

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1772,7 +1772,7 @@ function tryHandleMissingModule(error: any, document: TextDocument, library: ESL
 	return undefined;
 }
 
-const ignoredErrors: string[] = [];
+const ignoredErrors: Set<string> = new Set();
 
 function showErrorMessage(error: any, document: TextDocument): Status {
 	const errorMessage = `ESLint: ${getMessage(error, document)}. Please see the 'ESLint' output channel for details.`;
@@ -1780,13 +1780,13 @@ function showErrorMessage(error: any, document: TextDocument): Status {
 		{ title: 'Open Output', id: 1},
 		{ title: 'Ignore for this Session', id: 2}
 	];
-	if (!ignoredErrors.includes(errorMessage)) {
+	if (!ignoredErrors.has(errorMessage)) {
 		void connection.window.showErrorMessage(errorMessage, ...actions).then((value) => {
 			if (value !== undefined) {
 				if (value.id === 1) {
 					connection.sendNotification(ShowOutputChannel.type);
 				} else if (value.id === 2) {
-					ignoredErrors.push(errorMessage);
+					ignoredErrors.add(errorMessage);
 				}
 			}
 		});

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -1772,12 +1772,27 @@ function tryHandleMissingModule(error: any, document: TextDocument, library: ESL
 	return undefined;
 }
 
+const ignoredErrors: string[] = [];
+
 function showErrorMessage(error: any, document: TextDocument): Status {
-	void connection.window.showErrorMessage(`ESLint: ${getMessage(error, document)}. Please see the 'ESLint' output channel for details.`, { title: 'Open Output', id: 1}).then((value) => {
-		if (value !== undefined && value.id === 1) {
-			connection.sendNotification(ShowOutputChannel.type);
-		}
-	});
+	const errorMessage = `ESLint: ${getMessage(error, document)}. Please see the 'ESLint' output channel for details.`;
+	const actions = [
+		{ title: 'Open Output', id: 1},
+		{ title: 'Ignore for this Session', id: 2}
+	];
+	if (!ignoredErrors.includes(errorMessage)) {
+		void connection.window.showErrorMessage(errorMessage, ...actions).then((value) => {
+			if (value !== undefined) {
+				if (value.id === 1) {
+					connection.sendNotification(ShowOutputChannel.type);
+				} else if (value.id === 2) {
+					ignoredErrors.push(errorMessage);
+				}
+			}
+		});
+	} else {
+		connection.console.error(errorMessage);
+	}
 	if (Is.string(error.stack)) {
 		connection.console.error('ESLint stack trace:');
 		connection.console.error(error.stack);


### PR DESCRIPTION
This PR resolves #1206 by allowing users to ignore server errors _by error message_ until the server is restarted.

The error dialog is not displayed, but the error is still shown on the output channel.