### PR TITLE
fix: typescript probe not work properly on cnpm

### DIFF
--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -981,8 +981,8 @@ function getBlockComment(languageId: string): [string, string] {
 
 const languageId2ParserRegExp: Map<string, RegExp[]> = function createLanguageId2ParserRegExp() {
 	const result = new Map<string, RegExp[]>();
-	const typescript = /\/@typescript-eslint\/parser\//;
-	const babelESLint = /\/babel-eslint\/lib\/index.js$/;
+	const typescript = /@typescript-eslint\/parser\//;
+	const babelESLint = /babel-eslint\/lib\/index.js$/;
 	result.set('typescript', [typescript, babelESLint]);
 	result.set('typescriptreact', [typescript, babelESLint]);
 


### PR DESCRIPTION
fix probe detection on `cnpm install` scene

if project use `cnpm` to manage dependencies, it will use soft link to flat dep

![image](https://user-images.githubusercontent.com/1433247/149785807-2614bc93-0ba7-40fd-bb55-0a6d54319eaa.png)

use regex like this https://github.com/microsoft/vscode-eslint/blob/main/server/src/eslintServer.ts#L997 will fix it.