### PR TITLE
Use client capabilities

### DIFF
--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -382,10 +382,10 @@ namespace CommandIds {
 	export const openRuleDoc: string = 'eslint.openRuleDoc';
 }
 
-connection.onInitialize((_params, _cancel, progress) => {
+connection.onInitialize((params, _cancel, progress) => {
 	progress.begin('Initializing ESLint Server');
 	const syncKind: TextDocumentSyncKind = TextDocumentSyncKind.Incremental;
-	clientCapabilities = _params.capabilities;
+	clientCapabilities = params.capabilities;
 	progress.done();
 	const capabilities: ServerCapabilities = {
 		textDocumentSync: {


### PR DESCRIPTION
In order for the server to remain flexible and useful to many clients, the server must check the client's capabilities in the following scenarios:
1. Before including the `codeActionProvider` in its capabilities, it must ensure that the client signals code action literal support via the `textDocument.codeAction.codeActionLiteralSupport` property.
2. Before registering for the "workspace/didChangeConfiguration", the server must check that such dynamic registration is allowed.

This PR adds both checks.