### PR TITLE
Fix a typo in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
 					],
 					"enumDescriptions": [
 						"Fixes all possible problems in the file. This option might take some time.",
-						"Only fixes reported problems that have non overlapping textual edits. This options runs a lot faster."
+						"Fixes only reported problems that have non-overlapping textual edits. This option runs a lot faster."
 					],
 					"default": "all",
 					"markdownDescription": "Specifies the code action mode. Possible values are 'all' and 'problems'."


### PR DESCRIPTION
This PR fixes a typo in the tooltip description of the `eslint.codeActionsOnSave.mode` popup. It also corrects the grammar, changing “Only fixes” to the more correct “Fixes only”.