### PR TITLE
Change http to https for schemastore.org

### DIFF
--- a/package-json-schema.json
+++ b/package-json-schema.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema",
+	"$schema": "https://json-schema.org/draft-07/schema",
 	"properties": {
 		"eslintConfig": {
 			"description": "ESLint configuration",
-			"$ref": "http://json.schemastore.org/eslintrc"
+			"$ref": "https://json.schemastore.org/eslintrc"
 		}
 	}
 }


### PR DESCRIPTION
It seems that #1027 did not address all occurrences of `http`.

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/946853/185591799-2b00d47d-d01b-49c7-b7d2-eece4ee7de77.png">

See:
- https://github.com/microsoft/vscode/issues/40736
- https://github.com/microsoft/vscode/pull/40737