### PR TITLE
Introduce option to prevent underlining multiple lines

### DIFF
--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -163,6 +163,7 @@ export type ConfigurationSettings = {
 	options: ESLintOptions | undefined;
 	rulesCustomizations: RuleCustomization[];
 	run: RunValues;
+	singleLineUnderline: boolean;
 	nodePath: string | null;
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: ModeItem | DirectoryItem | undefined;

--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -163,7 +163,9 @@ export type ConfigurationSettings = {
 	options: ESLintOptions | undefined;
 	rulesCustomizations: RuleCustomization[];
 	run: RunValues;
-	singleLineUnderline: boolean;
+	problems: {
+		shortenToSingleLine: boolean;
+	};
 	nodePath: string | null;
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: ModeItem | DirectoryItem | undefined;

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -613,7 +613,9 @@ export namespace ESLintClient {
 					options: config.get<ESLintOptions>('options', {}),
 					rulesCustomizations: getRuleCustomizations(config, resource),
 					run: config.get<RunValues>('run', 'onType'),
-					singleLineUnderline: config.get<boolean>('singleLineUnderline', false),
+					problems: {
+						shortenToSingleLine: config.get<boolean>('problems.shortenToSingleLine', false),
+					},
 					nodePath: config.get<string | undefined>('nodePath', undefined) ?? null,
 					workingDirectory: undefined,
 					workspaceFolder: undefined,

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -613,6 +613,7 @@ export namespace ESLintClient {
 					options: config.get<ESLintOptions>('options', {}),
 					rulesCustomizations: getRuleCustomizations(config, resource),
 					run: config.get<RunValues>('run', 'onType'),
+					singleLineUnderline: config.get<boolean>('singleLineUnderline', false),
 					nodePath: config.get<string | undefined>('nodePath', undefined) ?? null,
 					workingDirectory: undefined,
 					workspaceFolder: undefined,

--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
 					"description": "Always show the ESlint status bar item.",
 					"scope": "window"
 				},
+				"eslint.singleLineUnderline": {
+					"type": "boolean",
+					"default": false,
+					"description": "Prevent a single error from underlining multiple lines.",
+					"scope": "resource"
+				},
 				"eslint.nodeEnv": {
 					"scope": "resource",
 					"type": [

--- a/package.json
+++ b/package.json
@@ -71,10 +71,10 @@
 					"description": "Always show the ESlint status bar item.",
 					"scope": "window"
 				},
-				"eslint.singleLineUnderline": {
+				"eslint.problems.shortenToSingleLine": {
 					"type": "boolean",
 					"default": false,
-					"description": "Prevent a single error from underlining multiple lines.",
+					"description": "Shorten the text spans of underlined problems to their first related line.",
 					"scope": "resource"
 				},
 				"eslint.nodeEnv": {

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -11,7 +11,7 @@ import { execSync } from 'child_process';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
 	Diagnostic, DiagnosticSeverity, DiagnosticTag, ProposedFeatures, Range, TextEdit, Files, DocumentFilter, DocumentFormattingRegistrationOptions,
-	Disposable, DocumentFormattingRequest, TextDocuments
+	Disposable, DocumentFormattingRequest, TextDocuments, uinteger
 } from 'vscode-languageserver/node';
 import { URI } from 'vscode-uri';
 
@@ -571,7 +571,7 @@ namespace Diagnostics {
 				},
 				end: {
 					line: startLine,
-					character: Number.MAX_SAFE_INTEGER,
+					character: uinteger.MAX_VALUE,
 				}
 			});
 			endLine = startLine;

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -540,7 +540,6 @@ export namespace RuleSeverities {
 	}
 }
 
-const documentsByProblem = new WeakMap<ESLintProblem, TextDocument>();
 
 /**
  * Creates LSP Diagnostis and captures code action information.
@@ -558,22 +557,21 @@ namespace Diagnostics {
 		return `[${range.start.line},${range.start.character},${range.end.line},${range.end.character}]-${diagnostic.code}-${message ?? ''}`;
 	}
 
-	export function create(settings: TextDocumentSettings, problem: ESLintProblem): [Diagnostic, RuleSeverity | undefined] {
+	export function create(settings: TextDocumentSettings, problem: ESLintProblem, document: TextDocument): [Diagnostic, RuleSeverity | undefined] {
 		const message = problem.message;
 		const startLine = typeof problem.line !== 'number' || Number.isNaN(problem.line) ? 0 : Math.max(0, problem.line - 1);
 		const startChar = typeof problem.column !== 'number' || Number.isNaN(problem.column) ? 0 : Math.max(0, problem.column - 1);
 		let endLine = typeof problem.endLine !== 'number' || Number.isNaN(problem.endLine) ? startLine : Math.max(0, problem.endLine - 1);
 		let endChar = typeof problem.endColumn !== 'number' || Number.isNaN(problem.endColumn) ? startChar : Math.max(0, problem.endColumn - 1);
 		if (settings.problems.shortenToSingleLine && endLine !== startLine) {
-			const document = documentsByProblem.get(problem)!;
 			const startLineText = document.getText({
 				start: {
 					line: startLine,
 					character: 0,
 				},
 				end: {
-					line: endLine,
-					character: 0,
+					line: startLine,
+					character: Number.MAX_SAFE_INTEGER,
 				}
 			});
 			endLine = startLine;
@@ -1049,8 +1047,7 @@ export namespace ESLint {
 				if (docReport.messages && Array.isArray(docReport.messages)) {
 					docReport.messages.forEach((problem) => {
 						if (problem) {
-							documentsByProblem.set(problem, document);
-							const [diagnostic, override] = Diagnostics.create(settings, problem);
+							const [diagnostic, override] = Diagnostics.create(settings, problem, document);
 							if (!(override === RuleSeverity.off || (settings.quiet && diagnostic.severity === DiagnosticSeverity.Warning))) {
 								diagnostics.push(diagnostic);
 							}

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -562,7 +562,7 @@ namespace Diagnostics {
 		const startChar = typeof problem.column !== 'number' || Number.isNaN(problem.column) ? 0 : Math.max(0, problem.column - 1);
 		let endLine = typeof problem.endLine !== 'number' || Number.isNaN(problem.endLine) ? startLine : Math.max(0, problem.endLine - 1);
 		let endChar = typeof problem.endColumn !== 'number' || Number.isNaN(problem.endColumn) ? startChar : Math.max(0, problem.endColumn - 1);
-		if (settings.singleLineUnderline && endLine !== startLine) {
+		if (settings.problems.shortenToSingleLine && endLine !== startLine) {
 			endLine = startLine;
 			endChar = text.split('\n')[startLine].length;
 		}

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -560,8 +560,17 @@ namespace Diagnostics {
 		const message = problem.message;
 		const startLine = typeof problem.line !== 'number' || Number.isNaN(problem.line) ? 0 : Math.max(0, problem.line - 1);
 		const startChar = typeof problem.column !== 'number' || Number.isNaN(problem.column) ? 0 : Math.max(0, problem.column - 1);
-		const endLine = typeof problem.endLine !== 'number' || Number.isNaN(problem.endLine) ? startLine : Math.max(0, problem.endLine - 1);
-		const endChar = typeof problem.endColumn !== 'number' || Number.isNaN(problem.endColumn) ? startChar : Math.max(0, problem.endColumn - 1);
+		let endLine = typeof problem.endLine !== 'number' || Number.isNaN(problem.endLine) ? startLine : Math.max(0, problem.endLine - 1);
+		let endChar: number;
+		if (settings.singleLineUnderline) {
+			endChar =
+				typeof problem.endColumn !== 'number' || Number.isNaN(problem.endColumn) || endLine !== startLine
+				  ? startChar
+				  : Math.max(0, problem.endColumn - 1);
+			endLine = startLine;
+		} else {
+			endChar = typeof problem.endColumn !== 'number' || Number.isNaN(problem.endColumn) ? startChar : Math.max(0, problem.endColumn - 1);
+		}
 		const override = RuleSeverities.getOverride(problem.ruleId, settings.rulesCustomizations);
 		const result: Diagnostic = {
 			message: message,


### PR DESCRIPTION
I rebased #463 in hopes that you'll reconsider merging this useful feature.

Your main concern seems to be consistency, but that's not a concern shared by ESLint maintainers:

> In [#8004](https://github.com/eslint/eslint/issues/8004), it was decided that ESLint should report large ranges if a node with a large range is reported by a rule, and **allow integrations to display a smaller report if desired**. The reasoning is that different integrations will have different needs with regard to report ranges (for example, an integration that posts comments on GitHub might want to know the entire reported range, whereas **an editor integration might only want to highlight a subset of a reported range**).
> [*Source*](https://github.com/eslint/eslint/issues/10424#issuecomment-394526121)


https://user-images.githubusercontent.com/1925840/192356428-aa9cf4a2-5870-4cf9-ac3a-0204fb635c32.mov

