### PR TITLE
Improve support for unwritten buffers

### DIFF
--- a/server/src/paths.ts
+++ b/server/src/paths.ts
@@ -85,11 +85,17 @@ export function getFileSystemPath(uri: URI): string {
 		result = result[0].toUpperCase() + result.substr(1);
 	}
 	if (process.platform === 'win32' || process.platform === 'darwin') {
-		const realpath = fs.realpathSync.native(result);
-		// Only use the real path if only the casing has changed.
-		if (realpath.toLowerCase() === result.toLowerCase()) {
-			result = realpath;
-		}
+    try {
+      const realpath = fs.realpathSync.native(result);
+      // Only use the real path if only the casing has changed.
+      if (realpath.toLowerCase() === result.toLowerCase()) {
+        result = realpath;
+      }
+    } catch {
+      // Silently ignore errors from `fs.realpathSync` to handle scenarios where
+      // the file being linted is not yet written to disk. This occurs in editors
+      // such as Neovim for non-written buffers.
+    }
 	}
 	return result;
 }


### PR DESCRIPTION
When using the ESLint language server in Neovim, creating a new unwritten buffer will cause the language server to crash due to `fs.realpathSync.native` throwing an exception since the file does not exist.  This change simply ignores errors from `fs.realpathSync.native` falling back to the original URI for the file.

It appears that the way this is handled for VS Code is that the extension will not call `getFileSystemPath` if the `uri.scheme` is `untitled`.  Neovim doesn't share this concept of an `untitled` URI scheme, but the change I made seems to still work fine in VS Code.

Thoughts?