### PR TITLE
Rename `eslint.runtime.execArgv` to `eslint.execArgv` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ This extension contributes the following variables to the [settings](https://cod
 - `eslint.run` - run the linter `onSave` or `onType`, default is `onType`.
 - `eslint.quiet` - ignore warnings.
 - `eslint.runtime` - use this setting to set the path of the node runtime to run ESLint under. [Use `"node"`](https://github.com/microsoft/vscode-eslint/issues/1233#issuecomment-815521280) if you want to use your default system version of node.
-- `eslint.runtime.execArgv` - use this setting to pass additional arguments to the node runtime like `--max_old_space_size=4096`
+- `eslint.execArgv` - use this setting to pass additional arguments to the node runtime like `--max_old_space_size=4096`
 - `eslint.nodeEnv` - use this setting if an ESLint plugin or configuration needs `process.env.NODE_ENV` to be defined.
 - `eslint.nodePath` - use this setting if an installed ESLint package can't be detected, for example `/myGlobalNodePackages/node_modules`.
 - `eslint.probe` - an array for language identifiers for which the ESLint extension should be activated and should try to validate the file. If validation fails for probed languages the extension says silent. Defaults to `["javascript", "javascriptreact", "typescript", "typescriptreact", "html", "vue", "markdown"]`.


### PR DESCRIPTION
This setting was renamed in 2.2.2: https://github.com/microsoft/vscode-eslint/blob/main/CHANGELOG.md#222