### PR TITLE
Reintroduce the enable and disable commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -573,6 +573,16 @@
 				"title": "Restart ESLint Server",
 				"category": "ESLint",
 				"command": "eslint.restart"
+			},
+			{
+				"title": "Enable ESLint",
+				"category": "ESLint",
+				"command": "eslint.enable"
+			},
+			{
+				"title": "Disable ESLint",
+				"category": "ESLint",
+				"command": "eslint.disable"
 			}
 		],
 		"taskDefinitions": [


### PR DESCRIPTION
This addresses #1281. It reintroduces the `Enable ESLint` and `Disable ESLint` commands that were removed in c54770579ed6f77cc278f799fd807cf6816c9b56.