### PR TITLE
Suggest npx in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Integrates [ESLint](http://eslint.org/) into VS Code. If you are new to ESLint c
 
 The extension uses the ESLint library installed in the opened workspace folder. If the folder doesn't provide one the extension looks for a global install version. If you haven't installed ESLint either locally or globally do so by running `npm install eslint` in the workspace folder for a local install or `npm install -g eslint` for a global install.
 
-On new folders you might also need to create a `.eslintrc` configuration file. You can do this by either using the VS Code command `Create ESLint configuration` or by running the `eslint` command in a terminal. If you have installed ESLint globally (see above) then run [`eslint --init`](http://eslint.org/docs/user-guide/command-line-interface) in a terminal. If you have installed ESLint locally then run [`.\node_modules\.bin\eslint --init`](http://eslint.org/docs/user-guide/command-line-interface) under Windows and [`./node_modules/.bin/eslint --init`](http://eslint.org/docs/user-guide/command-line-interface) under Linux and Mac.
+On new folders you might also need to create an `.eslintrc` configuration file. You can do this by either using the VS Code command `Create ESLint configuration` or by running the `eslint` command in a terminal with [`npx eslint --init`](http://eslint.org/docs/user-guide/command-line-interface).
 
 # Index
 * [Release Notes](#release-notes)


### PR DESCRIPTION
This PR updates the `README` to suggest the use of `npx` instead of specifying instructions for each operating system. By default, `npx` will check whether ESLint exists in `$PATH` (because it was installed globally), or in the local project binaries, and execute that.