### PR TITLE
fix: read only if `eslint.config.js` exists

### DIFF
--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -149,7 +149,7 @@ export namespace DirectoryItem {
 
 export type PackageManagers = 'npm' | 'yarn' | 'pnpm';
 
-export type ESLintOptions = object & { fixTypes?: string[] };
+export type ESLintOptions = object & { fixTypes?: string[], overrideConfig?: string | null };
 
 export type ConfigurationSettings = {
 	validate: Validate;

--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -163,7 +163,7 @@ export type ConfigurationSettings = {
 	format: boolean;
 	quiet: boolean;
 	onIgnoredFiles: ESLintSeverity;
-	options: ESLintOptions | undefined;
+	options: ESLintOptions;
 	rulesCustomizations: RuleCustomization[];
 	run: RunValues;
 	problems: {

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -866,10 +866,12 @@ export namespace ESLint {
 				moduleResolveWorkingDirectory = settings.workingDirectory.directory;
 			}
 
+			const ifUseFlatConfig = settings.experimental.useFlatConfig && fs.existsSync('eslint.config.js')
+
 			// During Flat Config is considered experimental,
 			// we need to import FlatESLint from 'eslint/use-at-your-own-risk'.
 			// See: https://eslint.org/blog/2022/08/new-config-system-part-3/
-			const eslintPath = settings.experimental.useFlatConfig ? 'eslint/use-at-your-own-risk' : 'eslint';
+			const eslintPath = ifUseFlatConfig? 'eslint/use-at-your-own-risk' : 'eslint';
 			if (nodePath !== undefined) {
 				promise = Files.resolve(eslintPath, nodePath, nodePath, trace).then<string, string>(undefined, () => {
 					return Files.resolve(eslintPath, settings.resolvedGlobalPackageManagerPath, moduleResolveWorkingDirectory, trace);
@@ -882,7 +884,7 @@ export namespace ESLint {
 			return promise.then(async (libraryPath) => {
 				let library = path2Library.get(libraryPath);
 				if (library === undefined) {
-					if (settings.experimental.useFlatConfig) {
+					if (ifUseFlatConfig) {
 						const lib = loadNodeModule<{ FlatESLint?: ESLintClassConstructor }>(libraryPath);
 						if (lib === undefined) {
 							settings.validate = Validate.off;

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -866,7 +866,11 @@ export namespace ESLint {
 				moduleResolveWorkingDirectory = settings.workingDirectory.directory;
 			}
 
-			const ifUseFlatConfig = settings.experimental.useFlatConfig && fs.existsSync('eslint.config.js')
+			const ifUseFlatConfig = settings.experimental.useFlatConfig
+				&& (
+					(settings.options?.overrideConfig && fs.existsSync(settings.options?.overrideConfig))
+					|| fs.existsSync('eslint.config.js')
+				);
 
 			// During Flat Config is considered experimental,
 			// we need to import FlatESLint from 'eslint/use-at-your-own-risk'.

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -866,11 +866,8 @@ export namespace ESLint {
 				moduleResolveWorkingDirectory = settings.workingDirectory.directory;
 			}
 
-			const ifUseFlatConfig = settings.experimental.useFlatConfig
-				&& (
-					(settings.options?.overrideConfig && fs.existsSync(settings.options?.overrideConfig))
-					|| fs.existsSync('eslint.config.js')
-				);
+			const flatConfigName = settings.options.overrideConfig ?? 'eslint.config.js';
+			const ifUseFlatConfig = settings.experimental.useFlatConfig && fs.existsSync(flatConfigName);
 
 			// During Flat Config is considered experimental,
 			// we need to import FlatESLint from 'eslint/use-at-your-own-risk'.


### PR DESCRIPTION
Now if `eslint.experimental.useFlatConfig` is enabled but `eslint.config.js` is not actually present, then the legacy config file will not take effect even if it is present.

This makes it necessary to change the enabled state of `eslint.experimental.useFlatConfig` depending on the configuration format used by the project.