### PR TITLE
fix(playgrounds-flatconfig): fix incorrect the key sourceType position

### DIFF
--- a/playgrounds/flatConfig/eslint.config.js
+++ b/playgrounds/flatConfig/eslint.config.js
@@ -7,9 +7,7 @@ module.exports = [
 	{
 		files: ["**/*.js"],
 		languageOptions: {
-			parserOptions: {
-				sourceType: "module"
-			},
+			sourceType: "module",
 			globals: {
 				...globals.browser,
 				...globals.node,
@@ -31,10 +29,10 @@ module.exports = [
 			"@typescript-eslint": typescriptPlugin
 		},
 		languageOptions: {
+			sourceType: "module",
 			parser: typescriptParser,
 			parserOptions: {
 				project: "./tsconfig.json",
-				sourceType: "module",
 				ecmaVersion: 2020
 			}
 		},


### PR DESCRIPTION
The key `sourceType` is direct under `languageOptions` according to [Configuration Files (New) in ESLint docs](https://eslint.org/docs/latest/use/configure/configuration-files-new#configuration-objects).