### PR TITLE
Support probing MDX

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,6 +310,7 @@
 						"typescript",
 						"typescriptreact",
 						"html",
+						"mdx",
 						"vue",
 						"markdown"
 					],

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -755,6 +755,7 @@ export namespace ESLint {
 		['json', 'jsonc'],
 		['json5', 'jsonc'],
 		['jsonc', 'jsonc'],
+		['mdx', 'mdx'],
 		['vue', 'vue'],
 		['markdown', 'markdown']
 	]);


### PR DESCRIPTION
This adds support for probing MDX based on [`eslint-plugin-mdx`](https://github.com/mdx-js/eslint-mdx/tree/master/packages/eslint-plugin-mdx). Probing MDX is is enabled by default for the `mdx` language id.