### PR TITLE
Support probing Astro

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
 						"type": "string"
 					},
 					"default": [
+						"astro",
 						"javascript",
 						"javascriptreact",
 						"typescript",

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -751,6 +751,7 @@ export namespace ESLint {
 	}();
 
 	const languageId2PluginName: Map<string, string> = new Map([
+		['astro', 'astro'],
 		['html', 'html'],
 		['json', 'jsonc'],
 		['json5', 'jsonc'],


### PR DESCRIPTION
This adds support for probing Astro based on [`eslint-plugin-astro`](https://github.com/ota-meshi/eslint-plugin-astro). Probing Astro is is enabled by default for the `astro` language id.