### PR TITLE
Hide all non-error messages when quiet mode is enabled

### DIFF
--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -1188,7 +1188,7 @@ export namespace ESLint {
 					docReport.messages.forEach((problem) => {
 						if (problem) {
 							const [diagnostic, override] = Diagnostics.create(settings, problem, document);
-							if (!(override === RuleSeverity.off || (settings.quiet && diagnostic.severity === DiagnosticSeverity.Warning))) {
+							if (!(override === RuleSeverity.off || (settings.quiet && diagnostic.severity !== DiagnosticSeverity.Error))) {
 								diagnostics.push(diagnostic);
 							}
 							if (fixTypes !== undefined && problem.ruleId !== undefined && problem.fix !== undefined) {


### PR DESCRIPTION
Change logic to hide all non-error messages instead of only hiding warn level messages (which missed info level messages)

Resolve #1803