### PR TITLE
feat: Allow eslint.rules.customizations to target all fixable rules

### DIFF
--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -109,6 +109,8 @@ export enum RuleSeverity {
 export type RuleCustomization = {
 	rule: string;
 	severity: RuleSeverity;
+	/** Only apply to autofixable rules */
+	fixable?: boolean;
 };
 
 export type RunValues = 'onType' | 'onSave';

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ This extension contributes the following variables to the [settings](https://cod
   - `"rule`": Select on rules with names that match, factoring in asterisks as wildcards: `{ "rule": "no-*", "severity": "warn" }`
     - Prefix the name with a `"!"` to target all rules that _don't_ match the name: `{ "rule": "!no-*", "severity": "info" }`
   - `"severity"`: Sets a new severity for matched rule(s), `"downgrade"`s them to a lower severity, `"upgrade"`s them to a higher severity, or `"default"`s them to their original severity
+  - `"fixable`": Select only autofixable rules: `{ "rule": "no-*", "fixable": true, "severity": "info" }`
 
   In this example, all rules are overridden to warnings:
 
@@ -329,6 +330,14 @@ This extension contributes the following variables to the [settings](https://cod
     { "rule": "no-*", "severity": "info" },
     { "rule": "!no-*", "severity": "downgrade" },
     { "rule": "radix", "severity": "default" }
+  ]
+  ```
+
+  In this example, all autofixable rules are overridden to info:
+
+  ```json
+  "eslint.rules.customizations": [
+    { "rule": "*", "fixable": true, "severity": "info" }
   ]
   ```
 

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -807,10 +807,18 @@ export namespace ESLintClient {
 
 			return rawConfig.map(rawValue => {
 				if (typeof rawValue.severity === 'string' && typeof rawValue.rule === 'string') {
-					return {
-						severity: rawValue.severity,
-						rule: rawValue.rule,
-					};
+					if (typeof rawValue.fixable === 'boolean') {
+						return {
+							severity: rawValue.severity,
+							rule: rawValue.rule,
+							fixable: rawValue.fixable
+						};
+					} else {
+						return {
+							severity: rawValue.severity,
+							rule: rawValue.rule,
+						};
+					}
 				}
 
 				return undefined;


### PR DESCRIPTION
With the config like this:

```js
"eslint.rules.customizations": [
    { "rule": "*", "fixable": true, "severity": "info" }
  ]
```

It'll downgrade all autofixable problems to the info severity.

Before:
<img width="254" alt="SCR-20240429-jkxc" src="https://github.com/microsoft/vscode-eslint/assets/70067/410abe2e-9d24-4d35-90f7-8cefa9a6b611">

After:
<img width="253" alt="SCR-20240429-jkse" src="https://github.com/microsoft/vscode-eslint/assets/70067/96f05d79-efeb-42c4-a0f8-7488629b34a9">



This pull request is based on abandoned #1705, and incorporates all the feedback.

Fixes #1634

Rel #267, #680, #655, #1705