### PR TITLE
Fix package manager detection

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -606,12 +606,12 @@ export namespace ESLintClient {
 				client.warn(`Detected package manager(${detectedPackageManager}) differs from the one in the deprecated eslint.packageManager setting(${userProvidedPackageManager}). We will honor this setting until it is removed.`, {}, true);
 				return userProvidedPackageManager;
 			}
-			if (!detectedPackageManager){
-				client.warn(`Failed to detect package manager.`, {}, true);
-				return 'npm'
+			if (detectedPackageManager === 'npm' || detectedPackageManager === 'yarn' || detectedPackageManager === 'pnpm'){
+				return detectedPackageManager;
 			}
 			
-			return detectedPackageManager;
+			client.warn(`Could not use detected package manager (${detectedPackageManager}). Defaulting to npm.`, {}, true);
+			return 'npm';
 		}
 
 		async function readConfiguration(params: ConfigurationParams): Promise<(ConfigurationSettings | null)[]> {

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -599,8 +599,8 @@ export namespace ESLintClient {
 		}
 
 		async function getPackageManager(uri: Uri) {
-			const userProvidedPackageManager:PackageManagers = Workspace.getConfiguration('eslint', uri).get('packageManager');
-			const detectedPackageManager = await commands.executeCommand<PackageManagers>('npm.packageManager', uri);
+			const userProvidedPackageManager: string | undefined = Workspace.getConfiguration('eslint', uri).get('packageManager');
+			const detectedPackageManager = await commands.executeCommand<string>('npm.packageManager', uri);
 
 			if (userProvidedPackageManager && detectedPackageManager && userProvidedPackageManager !== detectedPackageManager){
 				client.warn(`Detected package manager(${detectedPackageManager}) differs from the one in the deprecated eslint.packageManager setting(${userProvidedPackageManager}). We will honor this setting until it is removed.`, {}, true);


### PR DESCRIPTION
1. Previously, we were not passing uri to the `npm.packageManager` command, so it would [always return ''](https://github.com/microsoft/vscode/blob/6c3a7141c7be4a980076e14395ba2c3b5a76c971/extensions/npm/src/npmMain.ts#L66-L71). Now we pass that argument.
2. Previously, we were not checking the result of `npm.packageManager` (contributing to the above). Now we log a warning if it returns '' or a packageManager not supported by the eslint plugin.
3. Previously, if `eslint.packageManager` was omitted, we treated it as `'npm'` and could report `Detected package manager(...) differs from the one in the deprecated packageManager setting(npm)`. Now we never give that warning if the deprecated setting was not specified.
4. Previously the warning mentioned the "deprecated packageManager setting". Now it reports "deprecated eslint.packageManager setting" to disambiguate from the NOT deprecated `npm.packageManager` setting.