### PR TITLE
Add eslint.codeActionsOnSave.options

### DIFF
--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -67,6 +67,7 @@ export namespace CodeActionsOnSaveRules {
 export type CodeActionsOnSaveSettings = {
 	mode: CodeActionsOnSaveMode;
 	rules?: string[];
+	options?: ESLintOptions;
 };
 
 export enum ESLintSeverity {

--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -64,6 +64,15 @@ export namespace CodeActionsOnSaveRules {
 	}
 }
 
+export namespace CodeActionsOnSaveOptions {
+	export function from(value: object | undefined | null): ESLintOptions | undefined {
+		if (value === undefined || value === null || typeof value !== 'object') {
+			return undefined;
+		}
+		return value;
+	}
+}
+
 export type CodeActionsOnSaveSettings = {
 	mode: CodeActionsOnSaveMode;
 	rules?: string[];

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -20,7 +20,7 @@ import {
 
 import { LegacyDirectoryItem, Migration, PatternItem, ValidateItem } from './settings';
 import { ExitCalled, NoConfigRequest, NoESLintLibraryRequest, OpenESLintDocRequest, ProbeFailedRequest, ShowOutputChannel, Status, StatusNotification, StatusParams } from './shared/customMessages';
-import { CodeActionSettings, CodeActionsOnSaveMode, CodeActionsOnSaveRules, ConfigurationSettings, DirectoryItem, ESLintOptions, ESLintSeverity, ModeItem, PackageManagers, RuleCustomization, RunValues, Validate } from './shared/settings';
+import { CodeActionSettings, CodeActionsOnSaveMode, CodeActionsOnSaveOptions, CodeActionsOnSaveRules, ConfigurationSettings, DirectoryItem, ESLintOptions, ESLintSeverity, ModeItem, PackageManagers, RuleCustomization, RunValues, Validate } from './shared/settings';
 import { convert2RegExp, Is, Semaphore, toOSPath, toPosixPath } from './node-utils';
 import { pickFolder } from './vscode-utils';
 
@@ -713,7 +713,7 @@ export namespace ESLintClient {
 					settings.format = !!config.get<boolean>('format.enable', false);
 					settings.codeActionOnSave.mode = CodeActionsOnSaveMode.from(config.get<CodeActionsOnSaveMode>('codeActionsOnSave.mode', CodeActionsOnSaveMode.all));
 					settings.codeActionOnSave.rules = CodeActionsOnSaveRules.from(config.get<string[] | null>('codeActionsOnSave.rules', null));
-					settings.codeActionOnSave.options = CodeActionsOnSaveRules.from(config.get<string[] | null>('codeActionsOnSave.options', null));
+					settings.codeActionOnSave.options = CodeActionsOnSaveOptions.from(config.get<ESLintOptions | null>('codeActionsOnSave.options', null));
 				}
 				if (workspaceFolder !== undefined) {
 					settings.workspaceFolder = {

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -713,6 +713,7 @@ export namespace ESLintClient {
 					settings.format = !!config.get<boolean>('format.enable', false);
 					settings.codeActionOnSave.mode = CodeActionsOnSaveMode.from(config.get<CodeActionsOnSaveMode>('codeActionsOnSave.mode', CodeActionsOnSaveMode.all));
 					settings.codeActionOnSave.rules = CodeActionsOnSaveRules.from(config.get<string[] | null>('codeActionsOnSave.rules', null));
+					settings.codeActionOnSave.options = CodeActionsOnSaveRules.from(config.get<string[] | null>('codeActionsOnSave.options', null));
 				}
 				if (workspaceFolder !== undefined) {
 					settings.workspaceFolder = {

--- a/package.json
+++ b/package.json
@@ -461,7 +461,7 @@
 					"scope": "resource",
 					"type": "object",
 					"default": {},
-					"markdownDescription": "The eslint options object to use on save. (see https://eslint.org/docs/developer-guide/nodejs-api#eslint-class)."
+					"markdownDescription": "The eslint options object to use on save. (see https://eslint.org/docs/developer-guide/nodejs-api#eslint-class). eslint.codeActionsOnSave.rules, if specified, will take priority over any rule options here."
 				},
 				"eslint.format.enable": {
 					"scope": "resource",

--- a/package.json
+++ b/package.json
@@ -457,6 +457,12 @@
 					"default": null,
 					"markdownDescription": "The rules that should be executed when computing the code actions on save or formatting a file. Defaults to the rules configured via the ESLint configuration"
 				},
+				"eslint.codeActionsOnSave.options": {
+					"scope": "resource",
+					"type": "object",
+					"default": {},
+					"markdownDescription": "The eslint options object to use on save. (see https://eslint.org/docs/developer-guide/nodejs-api#eslint-class)."
+				},
 				"eslint.format.enable": {
 					"scope": "resource",
 					"type": "boolean",

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -18,7 +18,7 @@ import {
 import { URI } from 'vscode-uri';
 
 import { ProbeFailedParams, ProbeFailedRequest, NoESLintLibraryRequest, Status, NoConfigRequest, StatusNotification } from './shared/customMessages';
-import { ConfigurationSettings, DirectoryItem, ESLintSeverity, ModeEnum, ModeItem, PackageManagers, RuleCustomization, RuleSeverity, Validate } from './shared/settings';
+import { ConfigurationSettings, DirectoryItem, ESLintOptions, ESLintSeverity, ModeEnum, ModeItem, PackageManagers, RuleCustomization, RuleSeverity, Validate } from './shared/settings';
 
 import * as Is from './is';
 import { LRUCache } from './linkedMap';
@@ -471,7 +471,7 @@ export class Fixes {
 	}
 }
 
-export type SaveRuleConfigItem = { offRules: Set<string>; onRules: Set<string>};
+export type SaveRuleConfigItem = { offRules: Set<string>; onRules: Set<string>; options: ESLintOptions};
 
 /**
  * Manages the special save rule configurations done in the VS Code settings.
@@ -491,6 +491,7 @@ export namespace SaveRuleConfigs {
 			return result;
 		}
 		const rules = settings.codeActionOnSave.rules;
+		const options = settings.codeActionOnSave.options;
 		result = await ESLint.withClass(async (eslint) => {
 			if (rules === undefined || eslint.isCLIEngine) {
 				return undefined;
@@ -512,7 +513,7 @@ export namespace SaveRuleConfigs {
 					}
 				}
 			}
-			return offRules.size > 0 ? { offRules, onRules } : undefined;
+			return offRules.size > 0 ? { offRules, onRules, options: options ?? {} } : undefined;
 		}, settings);
 		if (result === undefined || result === null) {
 			saveRuleConfigCache.set(uri, null);


### PR DESCRIPTION
## Overview
Add an `eslint.codeActionsOnSave.options` that allows users to customize the options that ESLint runs with on save. This allows passing in a different set of options to ESLint on save.

If `eslint.codeActionsOnSave.rules` is specified, they will take priority over any rules specified in `eslint.codeActionsOnSave.options`. However, my use case for adding this is to specify a completely different config to provide faster on-save performance; more details in the test plan below.

See motivation in https://github.com/microsoft/vscode-eslint/issues/1938#issuecomment-2419913122.

## Testing
Tested manually on my codebase with the following settings:
```json
"editor.codeActionsOnSave": {
    "source.fixAll.eslint": "explicit"
},
"eslint.codeActionsOnSave.options": {
    "overrideConfigFile": "<workspaces path>/eslint.precommit.mjs",
    "fix": true,
    "fixTypes": ["problem", "suggestion", "layout"]
},
```

Verified that saving respected the precommit config and was faster than using the full config.
