### PR TITLE
Update contributing instructions

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -5,9 +5,8 @@
 Extension to integrate [ESLint](http://eslint.org/) into VS Code.
 
 ## Development setup
-- Use git with symbolic link support enabled
-- Run `npm install`
+- Use git with symbolic link support enabled. You can enable this with `git config core.symlinks true`.
+- Run `npm ci`
 - Open VS Code
 - Run the `watch` task to compile the client and server
 - To run/debug the extension use the `Launch Extension` launch configuration
-- To debug the server use the `Attach to Server` launch configuration


### PR DESCRIPTION
To ease contributions, this PR makes the following changes to `contributing.md`:
- Add the necessary `git` command to enable symlinks locally. 
- Replace `npm install` by `npm ci` to make `npm` use the `package-lock.json`.
- Removes the outdated reference to the "Attach to server" launch configuration.