### PR TITLE
Let the server determine cwd on its own

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -399,8 +399,8 @@ export namespace ESLintClient {
 			}
 			const debugArgv = ['--nolazy', '--inspect=6011'];
 			const result: ServerOptions = {
-				run: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv, cwd: process.cwd(), env } },
-				debug: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv: execArgv !== undefined ? execArgv.concat(debugArgv) : debugArgv, cwd: process.cwd(), env } }
+				run: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv, env } },
+				debug: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv: execArgv !== undefined ? execArgv.concat(debugArgv) : debugArgv, env } }
 			};
 			return result;
 		}


### PR DESCRIPTION


If `cwd` is not specified in the `ServerOptions` then the Language Server will use its own logic to determine the correct working directory, including the root of the workspace. This then allows `eslint.runtime` to be set to `"node"` which will be run in the root of the workspace. For projects using tools like Volta, this leads to it using the Volta-specified node version as expected.