### PR TITLE
refactor: replace substr with slice & use startsWith and endsWith

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -962,7 +962,7 @@ export namespace ESLintClient {
 			}
 
 			if (detail !== undefined && languageStatus.detail !== detail) {
-				 languageStatus.detail = detail;
+				languageStatus.detail = detail;
 			}
 			if (languageStatus.severity !== severity) {
 				languageStatus.severity = severity;

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -192,20 +192,20 @@ type ParserOptions = {
 };
 
 type ESLintRcConfig = {
- 	env: Record<string, boolean>;
+	env: Record<string, boolean>;
 	extends:  string | string[];
- 	// globals: Record<string, GlobalConf>;
- 	ignorePatterns: string | string[];
- 	noInlineConfig: boolean;
- 	// overrides: OverrideConfigData[];
- 	parser: string | null;
- 	parserOptions?: ParserOptions;
- 	plugins: string[];
- 	processor: string;
- 	reportUnusedDisableDirectives: boolean | undefined;
- 	root: boolean;
- 	rules: Record<string, RuleConf>;
- 	settings: object;
+	// globals: Record<string, GlobalConf>;
+	ignorePatterns: string | string[];
+	noInlineConfig: boolean;
+	// overrides: OverrideConfigData[];
+	parser: string | null;
+	parserOptions?: ParserOptions;
+	plugins: string[];
+	processor: string;
+	reportUnusedDisableDirectives: boolean | undefined;
+	root: boolean;
+	rules: Record<string, RuleConf>;
+	settings: object;
 };
 type ESLintConfig = ESLintRcConfig;
 
@@ -1167,7 +1167,7 @@ export namespace ESLint {
 		if (result.length === 0) {
 			return result;
 		}
-		return result[result.length - 1] === path.sep
+		return result.endsWith(path.sep)
 			? result.substring(0, result.length - 1)
 			: result;
 	}
@@ -1331,8 +1331,8 @@ export namespace ESLint {
 			if (typeof err.message === 'string' || err.message instanceof String) {
 				result = <string>err.message;
 				result = result.replace(/\r?\n/g, ' ');
-				if (/^CLI: /.test(result)) {
-					result = result.substr(5);
+				if (result.startsWith('CLI: ')) {
+					result = result.slice(5);
 				}
 			} else {
 				result = `An unknown error occurred while validating document: ${document.uri}`;

--- a/server/src/eslintServer.ts
+++ b/server/src/eslintServer.ts
@@ -136,7 +136,7 @@ function inferFilePath(documentOrUri: string | TextDocument | URI | undefined): 
 					const extension = LanguageDefaults.getExtension(textDocument.languageId);
 					if (extension !== undefined) {
 						const extname = path.extname(filePath);
-						if (extname.length === 0 && filePath[0] === '.') {
+						if (extname.length === 0 && filePath.startsWith('.')) {
 							return `${filePath}.${extension}`;
 						} else if (extname.length > 0 && extname !== extension) {
 							return `${filePath.substring(0, filePath.length - extname.length)}.${extension}`;
@@ -802,7 +802,7 @@ async function computeAllFixes(identifier: VersionedTextDocumentIdentifier, mode
 							start: textDocument.positionAt(diff.originalStart),
 							end: textDocument.positionAt(diff.originalStart + diff.originalLength)
 						},
-						newText: fixedContent.substr(diff.modifiedStart, diff.modifiedLength)
+						newText: fixedContent.slice(diff.modifiedStart, diff.modifiedStart + diff.modifiedLength)
 					});
 				}
 			}


### PR DESCRIPTION
I did the following refactoring.
- replace deprecated substr with slice
- use startsWith and endsWith for better readability
- fix lint warning