### PR TITLE
Support realpaths with true-defaulting config

### DIFF
--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -168,6 +168,7 @@ export type ConfigurationSettings = {
 	packageManager: PackageManagers;
 	useESLintClass: boolean;
 	useFlatConfig?: boolean | undefined;
+	useRealpaths: boolean;
 	experimental?: {
 		useFlatConfig: boolean;
 	};

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -678,6 +678,7 @@ export namespace ESLintClient {
 					packageManager: config.get<PackageManagers>('packageManager', 'npm'),
 					useESLintClass: config.get<boolean>('useESLintClass', false),
 					useFlatConfig: useFlatConfig === null ? undefined : useFlatConfig,
+					useRealpaths: config.get<boolean>('useRealpaths', true),
 					experimental: {
 						useFlatConfig: config.get<boolean>('experimental.useFlatConfig', false),
 					},

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -478,11 +478,11 @@ export type SaveRuleConfigItem = { offRules: Set<string>; onRules: Set<string>; 
  */
 export namespace SaveRuleConfigs {
 
-	export let inferFilePath: (documentOrUri: string | TextDocument | URI | undefined) => string | undefined;
+	export let inferFilePath: (documentOrUri: string | TextDocument | URI | undefined, useRealpaths: boolean) => string | undefined;
 
 	const saveRuleConfigCache = new LRUCache<string, SaveRuleConfigItem | null>(128);
 	export async function get(uri: string, settings: TextDocumentSettings  & { library: ESLintModule }): Promise<SaveRuleConfigItem | undefined> {
-		const filePath = inferFilePath(uri);
+		const filePath = inferFilePath(uri, settings.useRealpaths);
 		let result = saveRuleConfigCache.get(uri);
 		if (filePath === undefined || result === null) {
 			return undefined;
@@ -755,7 +755,7 @@ export namespace ESLint {
 
 	let connection: ProposedFeatures.Connection;
 	let documents: TextDocuments<TextDocument>;
-	let inferFilePath: (documentOrUri: string | TextDocument | URI | undefined) => string | undefined;
+	let inferFilePath: (documentOrUri: string | TextDocument | URI | undefined, useRealpaths: boolean) => string | undefined;
 	let loadNodeModule: <T>(moduleName: string) => T | undefined;
 
 	const languageId2ParserRegExp: Map<string, RegExp[]> = function createLanguageId2ParserRegExp() {
@@ -821,7 +821,7 @@ export namespace ESLint {
 	const document2Settings: Map<string, Promise<TextDocumentSettings>> = new Map<string, Promise<TextDocumentSettings>>();
 	const formatterRegistrations: Map<string, Promise<Disposable>> = new Map();
 
-	export function initialize($connection: ProposedFeatures.Connection, $documents: TextDocuments<TextDocument>, $inferFilePath: (documentOrUri: string | TextDocument | URI | undefined) => string | undefined, $loadNodeModule: <T>(moduleName: string) => T | undefined) {
+	export function initialize($connection: ProposedFeatures.Connection, $documents: TextDocuments<TextDocument>, $inferFilePath: (documentOrUri: string | TextDocument | URI | undefined, useRealpaths: boolean) => string | undefined, $loadNodeModule: <T>(moduleName: string) => T | undefined) {
 		connection = $connection;
 		documents = $documents;
 		inferFilePath = $inferFilePath;
@@ -868,8 +868,8 @@ export namespace ESLint {
 				return settings;
 			}
 			settings.resolvedGlobalPackageManagerPath = GlobalPaths.get(settings.packageManager);
-			const filePath = inferFilePath(document);
-			const workspaceFolderPath = settings.workspaceFolder !== undefined ? inferFilePath(settings.workspaceFolder.uri) : undefined;
+			const filePath = inferFilePath(document, settings.useRealpaths);
+			const workspaceFolderPath = settings.workspaceFolder !== undefined ? inferFilePath(settings.workspaceFolder.uri, settings.useRealpaths) : undefined;
 			let assumeFlatConfig:boolean = false;
 			const hasUserDefinedWorkingDirectories: boolean = configuration.workingDirectory !== undefined;
 			const workingDirectoryConfig = configuration.workingDirectory ?? { mode: ModeEnum.location };
@@ -1095,7 +1095,7 @@ export namespace ESLint {
 						if (!isFile) {
 							formatterRegistrations.set(uri, connection.client.register(DocumentFormattingRequest.type, options));
 						} else {
-							const filePath = inferFilePath(uri)!;
+							const filePath = inferFilePath(uri, settings.useRealpaths)!;
 							await ESLint.withClass(async (eslintClass) => {
 								if (!await eslintClass.isPathIgnored(filePath)) {
 									formatterRegistrations.set(uri, connection.client.register(DocumentFormattingRequest.type, options));
@@ -1181,14 +1181,14 @@ export namespace ESLint {
 		if (uri.scheme !== 'file') {
 			if (settings.workspaceFolder !== undefined) {
 				const ext = LanguageDefaults.getExtension(document.languageId);
-				const workspacePath = inferFilePath(settings.workspaceFolder.uri);
+				const workspacePath = inferFilePath(settings.workspaceFolder.uri, settings.useRealpaths);
 				if (workspacePath !== undefined && ext !== undefined) {
 					return path.join(workspacePath, `test.${ext}`);
 				}
 			}
 			return undefined;
 		} else {
-			return inferFilePath(uri);
+			return inferFilePath(uri, settings.useRealpaths);
 		}
 	}
 
@@ -1416,14 +1416,14 @@ export namespace ESLint {
 			missingModuleReported.clear();
 		}
 
-		function tryHandleMissingModule(error: any, document: TextDocument, library: ESLintModule): Status | undefined {
+		function tryHandleMissingModule(error: any, document: TextDocument, library: ESLintModule, settings: TextDocumentSettings): Status | undefined {
 			if (!error.message) {
 				return undefined;
 			}
 
 			function handleMissingModule(plugin: string, module: string, error: ESLintError): Status {
 				if (!missingModuleReported.has(plugin)) {
-					const fsPath = inferFilePath(document);
+					const fsPath = inferFilePath(document, settings.useRealpaths);
 					missingModuleReported.set(plugin, library);
 					if (error.messageTemplate === 'plugin-missing') {
 						connection.console.error([


### PR DESCRIPTION
Fixes #1972 

With this change:
Whenever `inferFilePath` is called, the setting for `useRealpaths` will determine whether realpath is used or not.
This does not apply to the call in `onDidChangeWatchedFiles` where we don't have access to settings without a bigger refactor but it doesn't seem crucial to ever realpath there (?)

I've tested this with [this](https://github.com/microsoft/vscode-eslint/issues/1972#issue-2795411595) very handy repro, and it behaves as expected in the symlinked directory opened in the extension development host:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/4a28c8ff-8e4d-46c9-bcc9-544ede73d03e" />
