### PR TITLE
Add probe support for Ember's glimmer-ts/glimmer-js format

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,7 +325,9 @@
 						"markdown",
 						"json",
 						"jsonc",
-						"css"
+						"css",
+						"glimmer-js",
+						"glimmer-ts"
 					],
 					"description": "An array of language ids for which the extension should probe if support is installed."
 				},

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -790,7 +790,9 @@ export namespace ESLint {
 		['mdx', 'mdx'],
 		['vue', 'vue'],
 		['markdown', 'markdown'],
-		['css', 'css']
+		['css', 'css'],
+		['glimmer-js', 'ember'],
+		['glimmer-ts', 'ember']
 	]);
 
 	const defaultLanguageIds: Set<string> = new Set([


### PR DESCRIPTION
This will allow the plugin to automatically support Ember's glimmer-js / glimmer-ts files without needing to manually configure `eslint.validate`