### PR TITLE
Fix workspaceFolder check to use optional chaining

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -623,7 +623,7 @@ export namespace ESLintClient {
 				const textDocument = getTextDocument(resource);
 				const config = Workspace.getConfiguration('eslint', textDocument ?? resource);
 				const workspaceFolder = resource.scheme === 'untitled'
-					? Workspace.workspaceFolders !== undefined ? Workspace.workspaceFolders[0] : undefined
+					? Workspace.workspaceFolders?.[0]
 					: Workspace.getWorkspaceFolder(resource);
 				await migrationSemaphore.lock(async () => {
 					const globalMigration = Workspace.getConfiguration('eslint').get('migration.2_x', 'on');


### PR DESCRIPTION
Use optional chaining for workspace folder lookup
- Uses optional chaining syntax that's already used elsewhere in the codebase
- No funtional changes to the behavior, but, improve code readability by eliminating the need to consider ternary operator precedence