### PR TITLE
Add ESLint cache support via new settings

### DIFF
--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -186,4 +186,10 @@ export type ConfigurationSettings = {
 	nodePath: string | null;
 	workspaceFolder: WorkspaceFolder | undefined;
 	workingDirectory: ModeItem | DirectoryItem | undefined;
+	/** Enables ESLint's result caching. Only effective when {@link run} is `onSave`. */
+	cache: boolean;
+	/** Path to the cache file. Defaults to `.eslintcache` in the working directory. Only used when {@link cache} is `true`. */
+	cacheLocation?: string;
+	/** Strategy for detecting changed files: `metadata` (faster) or `content`. Only used when {@link cache} is `true`. */
+	cacheStrategy?: 'metadata' | 'content';
 };

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -713,6 +713,9 @@ export namespace ESLintClient {
 					nodePath: config.get<string | undefined>('nodePath', undefined) ?? null,
 					workingDirectory: undefined,
 					workspaceFolder: undefined,
+					cache: config.get<boolean>('cache', false),
+					cacheLocation: config.get<string | undefined>('cacheLocation', undefined),
+					cacheStrategy: config.get<'metadata' | 'content' | undefined>('cacheStrategy', undefined),
 					codeAction: {
 						disableRuleComment: config.get<CodeActionSettings['disableRuleComment']>('codeAction.disableRuleComment', { enable: true, location: 'separateLine' as const, commentStyle: 'line' as const }),
 						showDocumentation: config.get<CodeActionSettings['showDocumentation']>('codeAction.showDocumentation', { enable: true })

--- a/package.json
+++ b/package.json
@@ -96,6 +96,26 @@
 					"default": {},
 					"markdownDescription": "The eslint options object to provide args normally passed to eslint when executed from a command line (see https://eslint.org/docs/developer-guide/nodejs-api#eslint-class)."
 				},
+				"eslint.cache": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Enables ESLint's cache when linting on save (`eslint.run` must be `onSave`). The cache file (`.eslintcache`) can be reused by command-line ESLint and pre-commit hooks, improving their performance."
+				},
+				"eslint.cacheLocation": {
+					"scope": "resource",
+					"type": "string",
+					"markdownDescription": "Path to the ESLint cache file. If not specified, defaults to `.eslintcache` in the working directory. Only used when `eslint.cache` is enabled."
+				},
+				"eslint.cacheStrategy": {
+					"scope": "resource",
+					"type": "string",
+					"enum": [
+						"metadata",
+						"content"
+					],
+					"markdownDescription": "Strategy for the ESLint cache to detect changed files. `metadata` uses file metadata (faster) while `content` uses file content (for environments where metadata is unreliable). Only used when `eslint.cache` is enabled."
+				},
 				"eslint.trace.server": {
 					"scope": "window",
 					"anyOf": [


### PR DESCRIPTION
Fixes #1844

Introduce three new settings — `eslint.cache`, `eslint.cacheLocation`, and `eslint.cacheStrategy` — that enable ESLint's built-in result caching when linting on save. When cache is active the server uses `lintFiles` (disk read) instead of `lintText` (in-memory) so the `.eslintcache` file is consulted and updated, which also benefits command-line ESLint and pre-commit hooks.