### PR TITLE
docs: Add missing document for `eslint.lintTask.command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ This extension contributes the following variables to the [settings](https://cod
     "eslint.lintTask.options": "-c C:/mydirectory/.eslintrc.json --ignore-path C:/mydirectory/.eslintignore ."
   }
   ```
+- `eslint.lintTask.command`: The command to run the task for linting the whole workspace. Defaults to the found eslint binary for the workspace, or 'eslint' if no binary could be found.
 - The old `eslint.packageManager` setting is now deprecated and can safely be removed. This controlled the package manager to be used to resolve the ESLint library. This has only an influence if the ESLint library is resolved globally. Valid values are `"npm"` or `"yarn"` or `"pnpm"`.
 - `eslint.options`: options to configure how ESLint is started using either the [ESLint class API](http://eslint.org/docs/developer-guide/nodejs-api#eslint-class) or the [CLIEngine API](http://eslint.org/docs/developer-guide/nodejs-api#cliengine). The extension uses the ESLint class API if ESLint version 8 or higher is used or if ESLint version 7 is used and the setting `eslint.useESLintCLass` is set to true. In all other cases the CLIEngine API is used.
   An example to point to a custom `.eslintrc.json` file using the new ESLint API is:
@@ -506,4 +507,5 @@ As with JavaScript validating TypeScript in a mono repository requires that you 
 ## ESLint 6.x
 
 Migrating from ESLint 5.x to ESLint 6.x might need some adaption (see the [ESLint Migration Guide](https://eslint.org/docs/user-guide/migrating-to-6.0.0) for details). Before filing an issue against the VS Code ESLint extension please ensure that you can successfully validate your files in a terminal using the eslint command.
+
 


### PR DESCRIPTION
Fixes #2125.