### PR TITLE
feat: surface bulk-suppressed ESLint violations as configurable diagnostics

### DIFF
--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -176,6 +176,11 @@ export type ConfigurationSettings = {
 	codeActionOnSave: CodeActionsOnSaveSettings;
 	format: boolean;
 	quiet: boolean;
+	bulkSuppression: {
+		enable: boolean;
+		suppressionsLocation?: string;
+		severity?: 'error' | 'warn' | 'info' | 'hint';
+	};
 	onIgnoredFiles: ESLintSeverity;
 	options: ESLintOptions | undefined;
 	rulesCustomizations: RuleCustomization[];

--- a/$shared/settings.ts
+++ b/$shared/settings.ts
@@ -178,7 +178,7 @@ export type ConfigurationSettings = {
 	quiet: boolean;
 	bulkSuppression: {
 		enable: boolean;
-		suppressionsLocation?: string;
+		location?: string;
 		severity?: 'error' | 'warn' | 'info' | 'hint';
 	};
 	onIgnoredFiles: ESLintSeverity;

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -703,6 +703,7 @@ export namespace ESLintClient {
 					},
 					format: false,
 					quiet: config.get<boolean>('quiet', false),
+					bulkSuppression: config.get<ConfigurationSettings['bulkSuppression']>('bulkSuppression', { enable: false }),
 					onIgnoredFiles: ESLintSeverity.from(config.get<string>('onIgnoredFiles', ESLintSeverity.off)),
 					options: config.get<ESLintOptions>('options', {}),
 					rulesCustomizations: getRuleCustomizations(config, resource),

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -703,7 +703,11 @@ export namespace ESLintClient {
 					},
 					format: false,
 					quiet: config.get<boolean>('quiet', false),
-					bulkSuppression: config.get<ConfigurationSettings['bulkSuppression']>('bulkSuppression', { enable: false }),
+					bulkSuppression: {
+						enable: config.get<boolean>('bulkSuppression.enable', false),
+						location: config.get<string | undefined>('bulkSuppression.location', undefined),
+						severity: config.get<string>('bulkSuppression.severity', 'info') as ConfigurationSettings['bulkSuppression']['severity'],
+					},
 					onIgnoredFiles: ESLintSeverity.from(config.get<string>('onIgnoredFiles', ESLintSeverity.off)),
 					options: config.get<ESLintOptions>('options', {}),
 					rulesCustomizations: getRuleCustomizations(config, resource),

--- a/package.json
+++ b/package.json
@@ -157,6 +157,29 @@
 					"default": false,
 					"description": "Turns on quiet mode, which ignores warnings and info diagnostics."
 				},
+				"eslint.bulkSuppression": {
+					"type": "object",
+					"scope": "resource",
+					"description": "Controls whether bulk-suppressed violations (from eslint-suppressions.json) are shown as hint diagnostics.",
+					"properties": {
+						"enable": {
+							"type": "boolean",
+							"default": false,
+							"description": "Show bulk-suppressed violations as hint (grey) diagnostics."
+						},
+						"suppressionsLocation": {
+							"type": "string",
+							"description": "Path to the suppressions file relative to the workspace. Defaults to eslint-suppressions.json."
+						},
+						"severity": {
+							"type": "string",
+							"enum": ["error", "warn", "info", "hint"],
+							"default": "info",
+							"description": "Diagnostic severity for bulk-suppressed violations. Defaults to 'info' (blue underline)."
+						}
+					},
+					"default": { "enable": false, "severity": "info" }
+				},
 				"eslint.onIgnoredFiles": {
 					"scope": "resource",
 					"type": "string",

--- a/package.json
+++ b/package.json
@@ -157,28 +157,23 @@
 					"default": false,
 					"description": "Turns on quiet mode, which ignores warnings and info diagnostics."
 				},
-				"eslint.bulkSuppression": {
-					"type": "object",
+				"eslint.bulkSuppression.enable": {
+					"type": "boolean",
 					"scope": "resource",
-					"description": "Controls whether bulk-suppressed violations (from eslint-suppressions.json) are shown as hint diagnostics.",
-					"properties": {
-						"enable": {
-							"type": "boolean",
-							"default": false,
-							"description": "Show bulk-suppressed violations as hint (grey) diagnostics."
-						},
-						"suppressionsLocation": {
-							"type": "string",
-							"description": "Path to the suppressions file relative to the workspace. Defaults to eslint-suppressions.json."
-						},
-						"severity": {
-							"type": "string",
-							"enum": ["error", "warn", "info", "hint"],
-							"default": "info",
-							"description": "Diagnostic severity for bulk-suppressed violations. Defaults to 'info' (blue underline)."
-						}
-					},
-					"default": { "enable": false, "severity": "info" }
+					"default": false,
+					"description": "Show bulk-suppressed violations (from eslint-suppressions.json) as diagnostics. Requires ESLint >= 10.1."
+				},
+				"eslint.bulkSuppression.location": {
+					"type": "string",
+					"scope": "resource",
+					"description": "Path to the suppressions file relative to the workspace. Defaults to eslint-suppressions.json."
+				},
+				"eslint.bulkSuppression.severity": {
+					"type": "string",
+					"scope": "resource",
+					"enum": ["error", "warn", "info", "hint"],
+					"default": "info",
+					"description": "Diagnostic severity for bulk-suppressed violations."
 				},
 				"eslint.onIgnoredFiles": {
 					"scope": "resource",

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -81,11 +81,16 @@ type ESLintProblem = {
 	suggestions?: ESLintSuggestionResult[];
 };
 
+type SuppressedESLintProblem = ESLintProblem & {
+	suppressions: Array<{ kind: string; justification: string }>;
+};
+
 type ESLintDocumentReport = {
 	filePath: string;
 	errorCount: number;
 	warningCount: number;
 	messages: ESLintProblem[];
+	suppressedMessages?: SuppressedESLintProblem[];
 	output?: string;
 };
 
@@ -115,6 +120,8 @@ export type ESLintClassOptions = {
 	fix?: boolean;
 	overrideConfig?: ConfigData;
 	overrideConfigFile?: string | null;
+	applySuppressions?: boolean;
+	suppressionsLocation?: string;
 };
 
 export type RuleMetaData = {
@@ -1195,6 +1202,15 @@ export namespace ESLint {
 		}
 	}
 
+	function bulkSeverity(severity?: 'error' | 'warn' | 'info' | 'hint'): DiagnosticSeverity {
+		switch (severity) {
+			case 'error': return DiagnosticSeverity.Error;
+			case 'warn':  return DiagnosticSeverity.Warning;
+			case 'hint':  return DiagnosticSeverity.Hint;
+			default:      return DiagnosticSeverity.Information;
+		}
+	}
+
 	const validFixTypes = new Set<string>(['problem', 'suggestion', 'layout', 'directive']);
 	export async function validate(document: TextDocument, settings: TextDocumentSettings & { library: ESLintModule }): Promise<Diagnostic[]> {
 		const newOptions: CLIOptions = Object.assign(Object.create(null), settings.options);
@@ -1214,6 +1230,15 @@ export namespace ESLint {
 		const content = document.getText();
 		const uri = document.uri;
 		const file = getFilePath(document, settings);
+
+		const suppressionOptions: ESLintClassOptions = settings.bulkSuppression?.enable
+			? {
+				applySuppressions: true,
+				...(settings.bulkSuppression.suppressionsLocation
+					? { suppressionsLocation: settings.bulkSuppression.suppressionsLocation }
+					: {}),
+			}
+			: {};
 
 		return withClass(async (eslintClass) => {
 			CodeActions.remove(uri);
@@ -1244,9 +1269,22 @@ export namespace ESLint {
 						}
 					});
 				}
+				// Bulk-suppressed diagnostics intentionally bypass `quiet` mode: they are opt-in
+				// and already represent a deliberate visibility decision by the user.
+				if (settings.bulkSuppression?.enable && docReport.suppressedMessages && Array.isArray(docReport.suppressedMessages)) {
+					for (const problem of docReport.suppressedMessages) {
+						if (problem && problem.suppressions?.some(s => s.kind === 'file')) {
+							const [diagnostic, override] = Diagnostics.create(settings, problem, document);
+							if (override !== RuleSeverity.off) {
+								diagnostic.severity = bulkSeverity(settings.bulkSuppression.severity);
+								diagnostics.push(diagnostic);
+							}
+						}
+					}
+				}
 			}
 			return diagnostics;
-		}, settings);
+		}, settings, suppressionOptions);
 	}
 
 	function trace(message: string, verbose?: string): void {

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -987,6 +987,9 @@ export namespace ESLint {
 							} else if (semverGte(esLintVersion, '10.0.0') && (settings.experimental?.useFlatConfig === false || settings.useFlatConfig === false)) {
 								connection.console.info(`ESLint version ${library.ESLint.version} only supports flat configs. Setting is ignored.`);
 							}
+							if (settings.bulkSuppression?.enable && !semverGte(esLintVersion, '10.1.0')) {
+								connection.console.warn(`ESLint version ${library.ESLint.version} does not support bulk suppressions via the Node.js API. Upgrade to ESLint >= 10.1 or disable 'eslint.bulkSuppression.enable'.`);
+							}
 						}
 					}
 				} else {
@@ -1234,8 +1237,8 @@ export namespace ESLint {
 		const suppressionOptions: ESLintClassOptions = settings.bulkSuppression?.enable
 			? {
 				applySuppressions: true,
-				...(settings.bulkSuppression.suppressionsLocation
-					? { suppressionsLocation: settings.bulkSuppression.suppressionsLocation }
+				...(settings.bulkSuppression.location
+					? { suppressionsLocation: settings.bulkSuppression.location }
 					: {}),
 			}
 			: {};


### PR DESCRIPTION
## Summary

- Adds `eslint.bulkSuppression.enable` setting (disabled by default — no behavior change for existing users)
- When enabled, violations moved to `suppressedMessages` by ESLint's bulk suppression API (`kind === \"file\"`) are emitted as VS Code diagnostics at a configurable severity (default: `info`)
- Respects `rulesCustomizations` — rules set to `off` are still suppressed
- Requires ESLint >= 10.1.0 ([eslint/eslint#20565](https://github.com/eslint/eslint/pull/20565))

## New settings

```jsonc
"eslint.bulkSuppression.enable": true,      // false by default
"eslint.bulkSuppression.severity": "hint",  // "error" | "warn" | "info" | "hint", defaults to "info"
"eslint.bulkSuppression.location": "path/to/eslint-suppressions.json" // optional
```

## Test plan

- [ ] With `enable: false` (default), no change in behavior
- [ ] With `enable: true`, open a file with a bulk-suppressed violation — it appears at the configured severity
- [ ] The same violation does not appear in `messages` (ESLint moved it to `suppressedMessages`)
- [ ] A rule customized to `off` via `rulesCustomizations` does not produce a bulk diagnostic
- [ ] `location` correctly overrides the default file path when set
- [ ] With ESLint < 10.1 and `enable: true`, a warning appears in the ESLint output channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)