### PR TITLE
Add basic settings.json setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ You can generate a starter config by running:
 
 `npx eslint --init`
 
+Example global starter settings.json:
+
+```json
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  }
+}
+```
+
+Workspace settings can vary across projects for specific validation:
+```json
+{
+ "eslint.validate": [
+    "javascript",
+    "typescript",
+    "vue"
+  ]
+}
+```
+
 Read more about [ESLint CLI](https://eslint.org/docs/latest/use/command-line-interface).
 
 For projects using older ESLint versions (< 8.57), use a legacy `.eslintrc` file (`.eslintrc.json`, `.eslintrc.js`, etc.).

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ Example global starter settings.json:
 
 ```json
 {
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   }


### PR DESCRIPTION
Referring back to  issue:
Provide a "basics" setup documentation for VSCode, ESLint & autoformatting #1204Provide a "basics" setup documentation for VSCode, ESLint & autoformatting [#1204](https://github.com/microsoft/vscode-eslint/issues/1204)

I've provided an example global configuration of settings.json to get started, and an example for workspaces for local settings.