### PR TITLE
Log restart success message to output channel

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -146,7 +146,9 @@ function realActivate(context: ExtensionContext): void {
 			if (client.state === State.StartFailed) {
 				await client.dispose();
 				[client, acknowledgePerformanceStatus] = ESLintClient.create(context, validator);
-				return client.start().catch((error) => {
+				return client.start().then(() => {
+					client.info('ESLint server restarted.');
+				}).catch((error) => {
 					client.error(`Starting the server failed.`, error, 'force');
 					const message = typeof error === 'string' ? error : typeof error.message === 'string' ? error.message : undefined;
 					if (message !== undefined && message.indexOf('ENOENT') !== -1) {
@@ -154,7 +156,9 @@ function realActivate(context: ExtensionContext): void {
 					}
 				});
 			} else {
-				return client.restart().catch((error) => client.error(`Restarting client failed`, error, 'force'));
+				return client.restart().then(() => {
+					client.info('ESLint server restarted.');
+				}).catch((error) => client.error(`Restarting client failed`, error, 'force'));
 			}
 		}),
 		Commands.registerCommand('eslint.revalidate', () => {


### PR DESCRIPTION
When diagnosing ESLint setup problems, I noticed there's no visual indication in the Output console when a restart succeeds. After fixing an issue (like installing the missing eslint package) and running "ESLint: Restart ESLint Server", the console still shows the old error with no follow-up message confirming that things are now working.

I added a simple `client.info('ESLint server restarted.')` line after both restart paths succeed. Now users get a clear signal that the server came back up without having to manually check if linting is working.

Closes #1792