### PR TITLE
Refactor experimental flat config handling

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -689,14 +689,20 @@ export namespace ESLintClient {
 					}
 				});
 				const useFlatConfig = config.get<boolean | null>('useFlatConfig', null);
+				const useExperimentalFlatConfig = config.get<boolean | null>('experimental.useFlatConfig', null);
 				const settings: ConfigurationSettings = {
 					validate: Validate.off,
 					packageManager: config.get<PackageManagers>('packageManager', 'npm'),
 					useESLintClass: config.get<boolean>('useESLintClass', false),
 					useFlatConfig: useFlatConfig === null ? undefined : useFlatConfig,
 					useRealpaths: config.get<boolean>('useRealpaths', false),
-					experimental: {
-						useFlatConfig: config.get<boolean>('experimental.useFlatConfig', false),
+					...{useExperimentalFlatConfig !== null
+						? {
+							experimental: {
+								useFlatConfig: useExperimentalFlatConfig,
+							}
+						}
+						: {}
 					},
 					codeActionOnSave: {
 						mode: CodeActionsOnSaveMode.all

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -689,14 +689,15 @@ export namespace ESLintClient {
 					}
 				});
 				const useFlatConfig = config.get<boolean | null>('useFlatConfig', null);
+				const useExperimentalFlatConfig = config.get<boolean | null>('experimental.useFlatConfig', null)
 				const settings: ConfigurationSettings = {
 					validate: Validate.off,
 					packageManager: config.get<PackageManagers>('packageManager', 'npm'),
 					useESLintClass: config.get<boolean>('useESLintClass', false),
 					useFlatConfig: useFlatConfig === null ? undefined : useFlatConfig,
 					useRealpaths: config.get<boolean>('useRealpaths', false),
-					experimental: {
-						useFlatConfig: config.get<boolean>('experimental.useFlatConfig', false),
+					experimental: useExperimentalFlatConfig === null ? undefined : {
+						useFlatConfig: useExperimentalFlatConfig,
 					},
 					codeActionOnSave: {
 						mode: CodeActionsOnSaveMode.all

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -689,20 +689,14 @@ export namespace ESLintClient {
 					}
 				});
 				const useFlatConfig = config.get<boolean | null>('useFlatConfig', null);
-				const useExperimentalFlatConfig = config.get<boolean | null>('experimental.useFlatConfig', null);
 				const settings: ConfigurationSettings = {
 					validate: Validate.off,
 					packageManager: config.get<PackageManagers>('packageManager', 'npm'),
 					useESLintClass: config.get<boolean>('useESLintClass', false),
 					useFlatConfig: useFlatConfig === null ? undefined : useFlatConfig,
 					useRealpaths: config.get<boolean>('useRealpaths', false),
-					...{useExperimentalFlatConfig !== null
-						? {
-							experimental: {
-								useFlatConfig: useExperimentalFlatConfig,
-							}
-						}
-						: {}
+					experimental: {
+						useFlatConfig: config.get<boolean>('experimental.useFlatConfig', false),
 					},
 					codeActionOnSave: {
 						mode: CodeActionsOnSaveMode.all

--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -993,10 +993,10 @@ export namespace ESLint {
 					if (library !== undefined && ESLintModule.hasESLintClass(library) && typeof library.ESLint.version === 'string') {
 						const esLintVersion = semverParse(library.ESLint.version);
 						if (esLintVersion !== null) {
-							if (semverGte(esLintVersion, '8.57.0') && settings.experimental?.useFlatConfig === true) {
+							if (semverGte(esLintVersion, '10.0.0') && (typeof settings.experimental?.useFlatConfig !== "undefined" || typeof settings.useFlatConfig !== "undefined")) {
+								connection.console.info(`ESLint version ${library.ESLint.version} only supports flat configs. The useFlatConfig setting is ignored.`);
+							} else if (semverGte(esLintVersion, '8.57.0') && settings.experimental?.useFlatConfig === true) {
 								connection.console.info(`ESLint version ${library.ESLint.version} supports flat config without experimental opt-in. The 'eslint.experimental.useFlatConfig' setting can be removed.`);
-							} else if (semverGte(esLintVersion, '10.0.0') && (settings.experimental?.useFlatConfig === false || settings.useFlatConfig === false)) {
-								connection.console.info(`ESLint version ${library.ESLint.version} only supports flat configs. Setting is ignored.`);
 							}
 						}
 					}


### PR DESCRIPTION
Prevent spurious `ESLint version 10.x.x only supports flat configs. Setting is ignored.` warnings by only adding the experimental setting if it exists in the file.

Closes Issue #2138