### PR TITLE
fix(server): handle null configuration settings

### DIFF
--- a/server/src/eslint.ts
+++ b/server/src/eslint.ts
@@ -19,7 +19,7 @@ import {
 import { URI } from 'vscode-uri';
 
 import { ProbeFailedParams, ProbeFailedRequest, NoESLintLibraryRequest, Status, NoConfigRequest, StatusNotification } from './shared/customMessages';
-import { ConfigurationSettings, DirectoryItem, ESLintOptions, ESLintSeverity, ModeEnum, ModeItem, PackageManagers, RuleCustomization, RuleSeverity, Validate } from './shared/settings';
+import { CodeActionsOnSaveMode, ConfigurationSettings, DirectoryItem, ESLintOptions, ESLintSeverity, ModeEnum, ModeItem, PackageManagers, RuleCustomization, RuleSeverity, Validate } from './shared/settings';
 
 import * as Is from './is';
 import { LRUCache } from './linkedMap';
@@ -861,6 +861,44 @@ export namespace ESLint {
 	const document2Settings: Map<string, Promise<TextDocumentSettings>> = new Map<string, Promise<TextDocumentSettings>>();
 	const formatterRegistrations: Map<string, Promise<Disposable>> = new Map();
 
+	function createDefaultConfigurationSettings(): ConfigurationSettings {
+		return {
+			validate: Validate.off,
+			packageManager: 'npm',
+			useESLintClass: false,
+			useRealpaths: false,
+			codeAction: {
+				disableRuleComment: {
+					enable: true,
+					location: 'separateLine',
+					commentStyle: 'line'
+				},
+				showDocumentation: {
+					enable: true
+				}
+			},
+			codeActionOnSave: {
+				mode: CodeActionsOnSaveMode.all
+			},
+			format: false,
+			quiet: false,
+			bulkSuppression: {
+				enable: false,
+				severity: 'info'
+			},
+			onIgnoredFiles: ESLintSeverity.off,
+			options: {},
+			rulesCustomizations: [],
+			run: 'onType',
+			problems: {
+				shortenToSingleLine: false
+			},
+			nodePath: null,
+			workspaceFolder: undefined,
+			workingDirectory: undefined
+		};
+	}
+
 	export function initialize($connection: ProposedFeatures.Connection, $documents: TextDocuments<TextDocument>, $inferFilePath: (documentOrUri: string | TextDocument | URI | undefined, useRealpaths: boolean) => string | undefined, $loadNodeModule: <T>(moduleName: string) => T | undefined) {
 		connection = $connection;
 		documents = $documents;
@@ -897,10 +935,11 @@ export namespace ESLint {
 		if (resultPromise) {
 			return resultPromise;
 		}
-		resultPromise = connection.workspace.getConfiguration({ scopeUri: uri, section: '' }).then((configuration: ConfigurationSettings) => {
+		resultPromise = connection.workspace.getConfiguration({ scopeUri: uri, section: '' }).then((configuration: ConfigurationSettings | null | undefined) => {
+			const resolvedConfiguration = Object.assign(createDefaultConfigurationSettings(), configuration ?? {});
 			const settings: TextDocumentSettings = Object.assign(
 				{},
-				configuration,
+				resolvedConfiguration,
 				{ silent: false, library: undefined, resolvedGlobalPackageManagerPath: undefined },
 				{ workingDirectory: undefined}
 			);
@@ -911,8 +950,8 @@ export namespace ESLint {
 			const filePath = inferFilePath(document, settings.useRealpaths);
 			const workspaceFolderPath = settings.workspaceFolder !== undefined ? inferFilePath(settings.workspaceFolder.uri, settings.useRealpaths) : undefined;
 			let assumeFlatConfig:boolean = false;
-			const hasUserDefinedWorkingDirectories: boolean = configuration.workingDirectory !== undefined;
-			const workingDirectoryConfig = configuration.workingDirectory ?? { mode: ModeEnum.location };
+			const hasUserDefinedWorkingDirectories: boolean = resolvedConfiguration.workingDirectory !== undefined;
+			const workingDirectoryConfig = resolvedConfiguration.workingDirectory ?? { mode: ModeEnum.location };
 			if (ModeItem.is(workingDirectoryConfig)) {
 				let candidate: string | undefined;
 				if (workingDirectoryConfig.mode === ModeEnum.location) {

--- a/server/src/tests/eslint.test.ts
+++ b/server/src/tests/eslint.test.ts
@@ -6,7 +6,10 @@
 import * as assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { Diagnostics } from '../eslint';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { Diagnostics, ESLint } from '../eslint';
+import { Validate } from '../shared/settings';
 
 void describe('ESLint diagnostics', () => {
 	void it('marks no-unused-vars diagnostics as unnecessary', () => {
@@ -39,5 +42,29 @@ void describe('ESLint diagnostics', () => {
 			message: '\'answer\' is assigned a value but never used.',
 			ruleId: undefined
 		}), true);
+	});
+});
+
+void describe('ESLint settings', () => {
+	void it('uses default settings when the client returns null configuration', async () => {
+		let configurationRequested = false;
+		const document = TextDocument.create('file:///workspace/test.js', 'javascript', 1, 'const answer = 42;\n');
+
+		ESLint.clearSettings();
+		ESLint.initialize({
+			workspace: {
+				getConfiguration: async () => {
+					configurationRequested = true;
+					return null;
+				}
+			}
+		} as any, {} as any, () => undefined, () => undefined);
+
+		const settings = await ESLint.resolveSettings(document);
+
+		assert.strictEqual(configurationRequested, true);
+		assert.strictEqual(settings.validate, Validate.off);
+		assert.strictEqual(settings.packageManager, 'npm');
+		assert.strictEqual(settings.workingDirectory, undefined);
 	});
 });


### PR DESCRIPTION
Fixes #2002.

This handles the case where an LSP client returns `null` from `workspace/configuration`. The server now falls back to default configuration settings before resolving document settings, so requests like `textDocument/codeAction` do not crash when no client configuration is available.

Added a regression test for `ESLint.resolveSettings` when `workspace.getConfiguration` returns `null`.

Validation:
- `npm run compile:server`
- `npm --prefix server test`
- `npm --prefix server run lint`