### PR TITLE
Merge release version 3.0.34 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Version 3.0.34 - release
+
+- add support for bulk suppression (see new settings eslint.bulkSuppression.*)
+- move to latest LSP libraries
+- [Bug fixes](https://github.com/microsoft/vscode-eslint/issues?q=is%3Aissue%20state%3Aclosed%20milestone%3A3.0.34)
+- [PRs](https://github.com/microsoft/vscode-eslint/pulls?q=is%3Apr+milestone%3A3.0.34+is%3Aclosed)
+
 ### Version 3.0.33 - pre-release
 
 - move to latest LSP libraries

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ This section describes major releases and their improvements. For a detailed lis
 
 From version 2.2.3 on forward odd minor or patch version numbers indicate an insider or pre-release. So versions `2.2.3`, `2.2.5` and `2.3.1` will all be pre-release versions. `2.2.10`, `2.4.10` and `3.0.0` will all be regular release versions.
 
+### Version 3.0.34 - release
+
+- add support for bulk suppression (see new settings eslint.bulkSuppression.*)
+- move to latest LSP libraries
+- [Bug fixes](https://github.com/microsoft/vscode-eslint/issues?q=is%3Aissue%20state%3Aclosed%20milestone%3A3.0.34)
+- [PRs](https://github.com/microsoft/vscode-eslint/pulls?q=is%3Apr+milestone%3A3.0.34+is%3Aclosed)
+
 ### Version 3.0.33 - pre-release
 
 - move to latest LSP libraries

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "client",
-	"version": "3.0.33",
+	"version": "3.0.34",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "client",
-			"version": "3.0.33",
+			"version": "3.0.34",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-languageclient": "10.1.0"

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
 	"name": "client",
 	"displayName": "ESLint",
 	"description": "Integrates ESLint into VS Code.",
-	"version": "3.0.33",
+	"version": "3.0.34",
 	"private": true,
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-eslint",
-	"version": "3.0.33",
+	"version": "3.0.34",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-eslint",
-			"version": "3.0.33",
+			"version": "3.0.34",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-eslint",
 	"displayName": "ESLint",
 	"description": "Integrates ESLint JavaScript into VS Code.",
-	"version": "3.0.33",
+	"version": "3.0.34",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
 	"repository": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "eslint-server",
-	"version": "3.0.33",
+	"version": "3.0.34",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "eslint-server",
-			"version": "3.0.33",
+			"version": "3.0.34",
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.8.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-server",
-	"version": "3.0.33",
+	"version": "3.0.34",
 	"private": true,
 	"author": "Microsoft Corporation",
 	"license": "MIT",


### PR DESCRIPTION
Introduce version 3.0.34, adding support for bulk suppression and updating to the latest LSP libraries. Include various bug fixes and closed PRs related to this release.